### PR TITLE
CI: build stable/unstable docs via gh-actions and publish to docs repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches: [master]
   pull_request:
+  release:
+    types: [published]
 
 name: docs
 
@@ -50,9 +52,19 @@ jobs:
         env: 
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 
-      - name: deploy
+      - name: Deploy stable docs
+        if: ${{ github.event_name == 'release' }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: target/doc/
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: gtk-rs/docs
+          destination_dir: stable/
+      - name: Deploy unstable docs
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc/
+          publish_dir: target/doc/
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: gtk-rs/docs
+          destination_dir: unstable/


### PR DESCRIPTION
The stable docs are generated for published releases and pushed to
`gtk-rs/gtk-rs.github.io` in the folder `docs/stable`.
The unstable docs are pushed to the same repo but to the folder
`docs/unstable`.

Note: this doesn't change the current docs, but could break `https://gtk-rs.org/docs` since the `docs` repo and the `gtk-rs/gtk-rs.github.io/docs` share the same url. Apparently the repo gets preference: https://stackoverflow.com/questions/25396383/does-a-folder-in-my-user-site-conflict-with-a-project-site

This requires the setup of a `deploy key` for the repo `gtk-rs/gtk-rs.github.io` which need to be exposed as `secrets.ACTIONS_DEPLOY_KEY`. It's pretty easy see here: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key

This is only the first step in solving the confusion about the docs locations and is the first step in resolving the issue https://github.com/gtk-rs/gtk-rs.github.io/issues/105.
This also allows us turn off the gh-pages for `gtk-rs` repo.