### PR TITLE
be able to inspect pango attribute types and downcast them

### DIFF
--- a/pango/src/attr_class.rs
+++ b/pango/src/attr_class.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use glib::translate::{FromGlibPtrFull, FromGlibPtrNone, Stash, ToGlibPtr};
+use crate::AttrType;
+use glib::translate::{from_glib, FromGlibPtrFull, FromGlibPtrNone, Stash, ToGlibPtr};
 
 #[doc(hidden)]
 impl<'a> ToGlibPtr<'a, *mut ffi::PangoAttrClass> for &'a AttrClass {
@@ -44,6 +45,12 @@ impl FromGlibPtrFull<*const ffi::PangoAttrClass> for AttrClass {
 }
 
 pub struct AttrClass(*mut ffi::PangoAttrClass);
+
+impl AttrClass {
+    pub fn type_(&self) -> AttrType {
+        unsafe { from_glib((*self.0).type_) }
+    }
+}
 
 impl PartialEq for AttrClass {
     fn eq(&self, other: &AttrClass) -> bool {

--- a/pango/src/attribute.rs
+++ b/pango/src/attribute.rs
@@ -243,7 +243,7 @@ macro_rules! define_attribute_struct {
         #[cfg(any(feature = "v1_44", feature = "dox"))]
         #[cfg_attr(feature = "dox", doc(cfg(feature = "v1_44")))]
         glib::wrapper! {
-            #[derive(Debug, PartialOrd, Ord, Hash)]
+            #[derive(Debug)]
             pub struct $rust_type(Boxed<$ffi_type>);
 
             match fn {
@@ -255,7 +255,7 @@ macro_rules! define_attribute_struct {
 
         #[cfg(not(any(feature = "v1_44", feature = "dox")))]
         glib::wrapper! {
-            #[derive(Debug, PartialOrd, Ord, Hash)]
+            #[derive(Debug)]
             pub struct $rust_type(Boxed<$ffi_type>);
 
             match fn {
@@ -263,27 +263,6 @@ macro_rules! define_attribute_struct {
                 free => |ptr| ffi::pango_attribute_destroy(ptr as *mut ffi::PangoAttribute),
             }
         }
-
-        impl $rust_type {
-            #[doc(alias = "pango_attribute_equal")]
-            fn equal(&self, attr2: &$rust_type) -> bool {
-                unsafe {
-                    from_glib(ffi::pango_attribute_equal(
-                        self.to_glib_none().0 as *const ffi::PangoAttribute,
-                        attr2.to_glib_none().0 as *const ffi::PangoAttribute,
-                    ))
-                }
-            }
-        }
-
-        impl PartialEq for $rust_type {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                self.equal(other)
-            }
-        }
-
-        impl Eq for $rust_type {}
 
         impl IsAttribute for $rust_type {
             const ATTR_TYPES: &'static [AttrType] = $attr_types;

--- a/pango/src/color.rs
+++ b/pango/src/color.rs
@@ -1,0 +1,18 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::Color;
+use glib::translate::*;
+
+impl Color {
+    pub fn red(&self) -> u16 {
+        unsafe { *self.to_glib_none().0 }.red
+    }
+
+    pub fn green(&self) -> u16 {
+        unsafe { *self.to_glib_none().0 }.green
+    }
+
+    pub fn blue(&self) -> u16 {
+        unsafe { *self.to_glib_none().0 }.blue
+    }
+}

--- a/pango/src/lib.rs
+++ b/pango/src/lib.rs
@@ -48,6 +48,10 @@ pub use crate::attr_class::AttrClass;
 pub mod attr_iterator;
 pub mod attr_list;
 pub mod attribute;
+pub use crate::attribute::{
+    AttrColor, AttrFloat, AttrFontDesc, AttrInt, AttrLanguage, IsAttribute,
+};
+pub mod color;
 mod functions;
 pub mod item;
 pub mod language;


### PR DESCRIPTION
Previously there was no way to determine the type of a pango attribute.  I added support for this, and the ability to downcast to actually read pango attributes.

Do you think I should go ahead and modify each attribute constructor to return a typed attribute and modify `AttrList`'s `change`, `insert`, and `insert_before` to take in any `IsAttribute`?

Any suggestions welcome.