### PR TITLE
glib: replace struct Continue with an enum

### DIFF
--- a/examples/cairo_threads/main.rs
+++ b/examples/cairo_threads/main.rs
@@ -128,7 +128,7 @@ fn build_ui(application: &gtk::Application) {
 
         area.queue_draw_area(origins[thread_num].0, origins[thread_num].1, WIDTH, HEIGHT);
 
-        Continue(true)
+        glib::source::Control::Continue
     });
 
     window.show_all();

--- a/examples/clock/main.rs
+++ b/examples/clock/main.rs
@@ -26,8 +26,8 @@ fn build_ui(application: &gtk::Application) {
     let tick = move || {
         let time = current_time();
         label.set_text(&time);
-        // we could return glib::Continue(false) to stop our clock after this tick
-        glib::Continue(true)
+        // we could return glib::source::Control::Remove to stop our clock after this tick
+        glib::source::Control::Continue
     };
 
     // executes the closure once every second

--- a/examples/list_store/main.rs
+++ b/examples/list_store/main.rs
@@ -63,9 +63,9 @@ fn build_ui(application: &gtk::Application) {
 
     glib::timeout_add_local(
         Duration::from_millis(80),
-        glib::clone!(@weak model => @default-return glib::Continue(false), move || {
+        glib::clone!(@weak model => @default-return glib::source::Control::Remove, move || {
             spinner_timeout(&model);
-            glib::Continue(false)
+            glib::source::Control::Remove
         }),
     );
 }
@@ -297,7 +297,7 @@ fn add_columns(model: &Rc<gtk::ListStore>, treeview: &gtk::TreeView) {
     }
 }
 
-fn spinner_timeout(model: &gtk::ListStore) -> Continue {
+fn spinner_timeout(model: &gtk::ListStore) -> glib::source::Control {
     let iter = model.iter_first().unwrap();
     let pulse = model
         .get_value(&iter, Columns::Pulse as i32)
@@ -314,5 +314,5 @@ fn spinner_timeout(model: &gtk::ListStore) -> Continue {
     model.set_value(&iter, Columns::Pulse as i32 as u32, &pulse.to_value());
     model.set_value(&iter, Columns::Active as i32 as u32, &true.to_value());
 
-    Continue(true)
+    glib::source::Control::Continue
 }

--- a/examples/multi_threading_context/main.rs
+++ b/examples/multi_threading_context/main.rs
@@ -48,7 +48,7 @@ fn build_ui(application: &gtk::Application) {
     rx.attach(None, move |text| {
         text_buffer.set_text(&text);
 
-        glib::Continue(true)
+        glib::source::Control::Continue
     });
 
     window.add(&scroll);

--- a/examples/progress_tracker/main.rs
+++ b/examples/progress_tracker/main.rs
@@ -66,7 +66,7 @@ impl Application {
                     let _ = tx.send(None);
                 });
 
-                rx.attach(None, glib::clone!(@weak active, @weak widgets => @default-return glib::Continue(false), move |value| match value {
+                rx.attach(None, glib::clone!(@weak active, @weak widgets => @default-return glib::source::Control::Remove, move |value| match value {
                     Some(value) => {
                         widgets
                             .main_view
@@ -78,20 +78,20 @@ impl Application {
                                 .view_stack
                                 .set_visible_child(&widgets.complete_view.container);
 
-                            glib::timeout_add_local(Duration::from_millis(1500), glib::clone!(@weak widgets => @default-return glib::Continue(false), move || {
+                            glib::timeout_add_local(Duration::from_millis(1500), glib::clone!(@weak widgets => @default-return glib::source::Control::Remove, move || {
                                 widgets.main_view.progress.set_fraction(0.0);
                                 widgets
                                     .view_stack
                                     .set_visible_child(&widgets.main_view.container);
-                                glib::Continue(false)
+                                glib::source::Control::Remove
                             }));
                         }
 
-                        glib::Continue(true)
+                        glib::source::Control::Continue
                     }
                     None => {
                         active.set(false);
-                        glib::Continue(false)
+                        glib::source::Control::Remove
                     }
                 }));
             }),

--- a/examples/tree_view/main.rs
+++ b/examples/tree_view/main.rs
@@ -59,12 +59,12 @@ fn build_ui(application: &gtk::Application) {
         .map_err(|err| {
             let msg = err.to_string();
             glib::idle_add_local(
-                glib::clone!(@weak window => @default-return glib::Continue(false), move || {
+                glib::clone!(@weak window => @default-return glib::source::Control::Remove, move || {
                     let dialog = MessageDialog::new(Some(&window), DialogFlags::MODAL,
                         MessageType::Error, ButtonsType::Ok, &msg);
                     dialog.connect_response(|dialog, _| dialog.close());
                     dialog.show_all();
-                    Continue(false)
+                    glib::source::Control::Remove
                 }),
             );
         })

--- a/glib/src/prelude.rs
+++ b/glib/src/prelude.rs
@@ -3,6 +3,6 @@
 //! Traits and essential types intended for blanket imports.
 
 pub use crate::{
-    Cast, Continue, IsA, ObjectExt, ObjectType, ParamSpecType, StaticType, StaticVariantType,
-    ToSendValue, ToValue, ToVariant,
+    Cast, IsA, ObjectExt, ObjectType, ParamSpecType, StaticType, StaticVariantType, ToSendValue,
+    ToValue, ToVariant,
 };

--- a/glib/src/source_futures.rs
+++ b/glib/src/source_futures.rs
@@ -10,7 +10,7 @@ use std::pin;
 use std::pin::Pin;
 use std::time::Duration;
 
-use crate::Continue;
+use crate::Control;
 use crate::MainContext;
 use crate::Priority;
 use crate::Source;
@@ -120,7 +120,7 @@ pub fn timeout_future_with_priority(
         let mut send = Some(send);
         crate::timeout_source_new(value, None, priority, move || {
             let _ = send.take().unwrap().send(());
-            Continue(false)
+            Control::Remove
         })
     }))
 }
@@ -143,7 +143,7 @@ pub fn timeout_future_seconds_with_priority(
         let mut send = Some(send);
         crate::timeout_source_new_seconds(value, None, priority, move || {
             let _ = send.take().unwrap().send(());
-            Continue(false)
+            Control::Remove
         })
     }))
 }
@@ -198,7 +198,7 @@ pub fn unix_signal_future_with_priority(
         let mut send = Some(send);
         crate::unix_signal_source_new(signum, None, priority, move || {
             let _ = send.take().unwrap().send(());
-            Continue(false)
+            Control::Remove
         })
     }))
 }
@@ -308,9 +308,9 @@ pub fn interval_stream_with_priority(
     Box::pin(SourceStream::new(move |send| {
         crate::timeout_source_new(value, None, priority, move || {
             if send.unbounded_send(()).is_err() {
-                Continue(false)
+                Control::Remove
             } else {
-                Continue(true)
+                Control::Continue
             }
         })
     }))
@@ -333,9 +333,9 @@ pub fn interval_stream_seconds_with_priority(
     Box::pin(SourceStream::new(move |send| {
         crate::timeout_source_new_seconds(value, None, priority, move || {
             if send.unbounded_send(()).is_err() {
-                Continue(false)
+                Control::Remove
             } else {
-                Continue(true)
+                Control::Continue
             }
         })
     }))
@@ -362,9 +362,9 @@ pub fn unix_signal_stream_with_priority(
     Box::pin(SourceStream::new(move |send| {
         crate::unix_signal_source_new(signum, None, priority, move || {
             if send.unbounded_send(()).is_err() {
-                Continue(false)
+                Control::Remove
             } else {
-                Continue(true)
+                Control::Continue
             }
         })
     }))

--- a/gtk/src/widget.rs
+++ b/gtk/src/widget.rs
@@ -4,8 +4,8 @@ use gdk::{DragAction, Event, ModifierType};
 use glib::ffi::gboolean;
 use glib::object::{Cast, IsA, WeakRef};
 use glib::signal::{connect_raw, Inhibit, SignalHandlerId};
+use glib::source::Control;
 use glib::translate::*;
-use glib::Continue;
 use glib::ObjectExt;
 use std::mem::transmute;
 use std::ptr;
@@ -52,7 +52,7 @@ pub trait WidgetExtManual: 'static {
     ) -> SignalHandlerId;
 
     #[doc(alias = "gtk_widget_add_tick_callback")]
-    fn add_tick_callback<P: Fn(&Self, &gdk::FrameClock) -> Continue + 'static>(
+    fn add_tick_callback<P: Fn(&Self, &gdk::FrameClock) -> Control + 'static>(
         &self,
         callback: P,
     ) -> TickCallbackId;
@@ -197,7 +197,7 @@ impl<O: IsA<Widget>> WidgetExtManual for O {
         }
     }
 
-    fn add_tick_callback<P: Fn(&Self, &gdk::FrameClock) -> Continue + 'static>(
+    fn add_tick_callback<P: Fn(&Self, &gdk::FrameClock) -> Control + 'static>(
         &self,
         callback: P,
     ) -> TickCallbackId {
@@ -205,7 +205,7 @@ impl<O: IsA<Widget>> WidgetExtManual for O {
 
         unsafe extern "C" fn callback_func<
             O: IsA<Widget>,
-            P: Fn(&O, &gdk::FrameClock) -> Continue + 'static,
+            P: Fn(&O, &gdk::FrameClock) -> Control + 'static,
         >(
             widget: *mut ffi::GtkWidget,
             frame_clock: *mut gdk::ffi::GdkFrameClock,
@@ -221,7 +221,7 @@ impl<O: IsA<Widget>> WidgetExtManual for O {
 
         unsafe extern "C" fn notify_func<
             O: IsA<Widget>,
-            P: Fn(&O, &gdk::FrameClock) -> Continue + 'static,
+            P: Fn(&O, &gdk::FrameClock) -> Control + 'static,
         >(
             data: glib::ffi::gpointer,
         ) {


### PR DESCRIPTION
Having `Continue(true)` and `Continue(false)` does not look very idiomatic. Using an `enum` is more natural.

However using an enum also means that we need to come up with a name for it... This patch proposes `Control`, but I am open to any better ideas. For now I did not add `Control` to the prelude.

