### PR TITLE
gtk: drop MainContext check

### DIFF
--- a/gtk/src/rt.rs
+++ b/gtk/src/rt.rs
@@ -117,10 +117,6 @@ pub fn init() -> Result<(), glib::BoolError> {
         let argv = ::std::env::args().take(1).collect::<Vec<_>>();
 
         if from_glib(ffi::gtk_init_check(&mut 1, &mut argv.to_glib_none().0)) {
-            if !glib::MainContext::default().is_owner() {
-                return Err(glib::bool_error!("Failed to acquire default main context"));
-            }
-
             set_initialized();
             Ok(())
         } else {


### PR DESCRIPTION
there's no need to ensure we are initializing gtk on the main thread
if gtk was not initialized yet