### PR TITLE
docs: fix the release condition

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - run: cargo install rustdoc-stripper
       - run: python3 ./generator.py --embed-docs --yes ./
       - run: git clone https://gitlab.gnome.org/World/Rust/gir-rustdoc/ # checkout action doesn't support random urls
-      - run: echo "RUSTDOCFLAGS=$(eval python3 ./gir-rustdoc/gir-rustdoc.py --pages-url 'https://gtk-rs.org/gtk3-rs/' --default-branch 'master' --branch 'master' pre-docs | xargs)" >> ${GITHUB_ENV}
+      - run: echo "RUSTDOCFLAGS=$(eval python3 ./gir-rustdoc/gir-rustdoc.py --pages-url 'https://gtk-rs.org/gtk3-rs/' --default-branch 'master' pre-docs | xargs)" >> ${GITHUB_ENV}
       - uses: actions-rs/cargo@v1
         with:
           command: doc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           command: doc
           args: -p atk -p atk-sys -p gdk -p gdk-sys -p gdkx11 -p gdkx11-sys -p gtk -p gtk3-macros -p gtk-sys --features dox --no-deps
-      - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" == "release" ]; then echo 'stable/${{ github.event.release.tag_name }}'; else echo 'git'; fi)" >> ${GITHUB_ENV}
+      - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" = "release" ]; then echo 'stable/${{ github.event.release.tag_name }}'; else echo 'git'; fi)" >> ${GITHUB_ENV}
 
       - name: Grab gtk-rs LOGO
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release' }}


### PR DESCRIPTION
Otherwise the  condition fails and the value is always set to `git`  which is the reason why we still don't have stable docs for the released versions. Once this patch is merged, a temporary `0.14` release has to be created to trigger the docs job 