### PR TITLE
CI: latest docs should be the first

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,8 @@ jobs:
       image: ghcr.io/gtk-rs/gtk3-rs/gtk3:latest
     env:
       RELEASES: |
-        0.9=0.9
         0.14=0.14
+        0.9=0.9
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
otherwise gir-rustdoc says our latest docs are old :p