### PR TITLE
Rename Window::focus into Windows::focused_widget

### DIFF
--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -2925,6 +2925,9 @@ manual_traits = ["GtkWindowExtManual"]
         [[object.function.parameter]]
         name = "geometry"
         const = true
+    [[object.function]]
+    name = "get_focus"
+    rename = "focused_widget"
     [[object.signal]] # workaround for https://github.com/gtk-rs/gtk/issues/985
     name = "set-focus"
         [[object.signal.parameter]]

--- a/gtk/src/auto/window.rs
+++ b/gtk/src/auto/window.rs
@@ -812,7 +812,7 @@ pub trait GtkWindowExt: 'static {
 
     #[doc(alias = "gtk_window_get_focus")]
     #[doc(alias = "get_focus")]
-    fn focus(&self) -> Option<Widget>;
+    fn focused_widget(&self) -> Option<Widget>;
 
     #[doc(alias = "gtk_window_get_focus_on_map")]
     #[doc(alias = "get_focus_on_map")]
@@ -1405,7 +1405,7 @@ impl<O: IsA<Window>> GtkWindowExt for O {
         }
     }
 
-    fn focus(&self) -> Option<Widget> {
+    fn focused_widget(&self) -> Option<Widget> {
         unsafe { from_glib_none(ffi::gtk_window_get_focus(self.as_ref().to_glib_none().0)) }
     }
 


### PR DESCRIPTION
Fixes #604.

`focus_widget` seemed wrong too so I picked `focused_widget` instead.