### PR TITLE
gtk: Fix usage of pthread_main_np() return value

### DIFF
--- a/gtk/src/rt.rs
+++ b/gtk/src/rt.rs
@@ -86,7 +86,7 @@ pub unsafe fn set_initialized() {
     {
         assert_eq!(
             pthread_main_np(),
-            0,
+            1,
             "Attempted to initialize GTK on OSX from non-main thread"
         );
     }


### PR DESCRIPTION
It returns 1 in the case we care about (main thread) and 0 or -1
otherwise.