### PR TITLE
gtk: manually implement gtk_print_operation_get_error

### DIFF
--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -1772,6 +1772,10 @@ status = "generate"
 name = "Gtk.PrintOperation"
 status = "generate"
 generate_builder = true
+    [[object.function]]
+    name = "get_error"
+    # It quacks like a fallible function, but it isn't.
+    ignore = true
 
 [[object]]
 name = "Gtk.PrintSettings"

--- a/gtk/src/auto/print_operation.rs
+++ b/gtk/src/auto/print_operation.rs
@@ -233,10 +233,6 @@ pub trait PrintOperationExt: 'static {
     #[doc(alias = "get_embed_page_setup")]
     fn embeds_page_setup(&self) -> bool;
 
-    #[doc(alias = "gtk_print_operation_get_error")]
-    #[doc(alias = "get_error")]
-    fn error(&self) -> Result<(), glib::Error>;
-
     #[doc(alias = "gtk_print_operation_get_has_selection")]
     #[doc(alias = "get_has_selection")]
     fn has_selection(&self) -> bool;
@@ -483,18 +479,6 @@ impl<O: IsA<PrintOperation>> PrintOperationExt for O {
             from_glib(ffi::gtk_print_operation_get_embed_page_setup(
                 self.as_ref().to_glib_none().0,
             ))
-        }
-    }
-
-    fn error(&self) -> Result<(), glib::Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let _ = ffi::gtk_print_operation_get_error(self.as_ref().to_glib_none().0, &mut error);
-            if error.is_null() {
-                Ok(())
-            } else {
-                Err(from_glib_full(error))
-            }
         }
     }
 

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -99,6 +99,7 @@ mod pad_action_entry;
 #[cfg(any(feature = "v3_22", feature = "dox"))]
 mod pad_controller;
 mod page_range;
+mod print_operation;
 mod print_settings;
 mod radio_button;
 mod radio_menu_item;

--- a/gtk/src/print_operation.rs
+++ b/gtk/src/print_operation.rs
@@ -1,0 +1,21 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::PrintOperation;
+use glib::translate::*;
+use std::ptr;
+
+impl PrintOperation {
+    #[doc(alias = "gtk_print_operation_get_error")]
+    #[doc(alias = "get_error")]
+    pub fn error(&self) -> Option<glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            ffi::gtk_print_operation_get_error(self.to_glib_none().0, &mut error);
+            if error.is_null() {
+                None
+            } else {
+                Some(from_glib_full(error))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This moves `gtk_print_operation_get_error` to a manual wrapper.
It quacks like a fallible function, but it isn't. That was resulting in a wrong
auto-generated wrapper.