### PR TITLE
manually implement Container::(get|set)_property

### DIFF
--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -854,9 +854,10 @@ generate_builder = true
 [[object]]
 name = "Gtk.Container"
 status = "generate"
+manual_traits = ["ContainerExtManual"]
     [[object.function]]
     pattern = "child_[gs]et_property"
-    ignore = true
+    manual = true
     [[object.function]]
     name = "propagate_draw"
         [[object.function.parameter]]

--- a/gtk/src/container.rs
+++ b/gtk/src/container.rs
@@ -1,0 +1,110 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{Container, Widget};
+use glib::translate::*;
+use glib::{value::FromValue, IsA, ToValue};
+
+pub trait ContainerExtManual: 'static {
+    #[doc(alias = "gtk_container_child_get_property")]
+    fn child_property_value(&self, child: &impl IsA<Widget>, property_name: &str) -> glib::Value;
+
+    #[doc(alias = "gtk_container_child_get_property")]
+    fn child_property<V: for<'b> FromValue<'b> + 'static>(
+        &self,
+        child: &impl IsA<Widget>,
+        property_name: &str,
+    ) -> V;
+
+    #[doc(alias = "gtk_container_child_set_property")]
+    fn child_set_property(
+        &self,
+        child: &impl IsA<Widget>,
+        property_name: &str,
+        value: &dyn ToValue,
+    );
+}
+
+impl<O: IsA<Container>> ContainerExtManual for O {
+    fn child_property_value(&self, child: &impl IsA<Widget>, property_name: &str) -> glib::Value {
+        unsafe {
+            let container_class = glib::Class::<Container>::from_type(O::static_type()).unwrap();
+            let pspec: Option<glib::ParamSpec> =
+                from_glib_none(ffi::gtk_container_class_find_child_property(
+                    container_class.as_ref() as *const _ as *const glib::gobject_ffi::GObjectClass,
+                    property_name.to_glib_none().0,
+                ));
+            let pspec = pspec.unwrap_or_else(|| {
+                panic!("The Container property '{}' doesn't exists", property_name)
+            });
+
+            if !pspec.flags().contains(glib::ParamFlags::READABLE)
+                || !pspec.flags().contains(glib::ParamFlags::READWRITE)
+            {
+                panic!("The Container property '{}' is not readable", property_name);
+            }
+
+            let mut value = glib::Value::from_type(pspec.value_type());
+            ffi::gtk_container_child_get_property(
+                self.as_ref().to_glib_none().0,
+                child.as_ref().to_glib_none().0,
+                property_name.to_glib_none().0,
+                value.to_glib_none_mut().0,
+            );
+            value
+        }
+    }
+
+    fn child_property<V: for<'b> FromValue<'b> + 'static>(
+        &self,
+        child: &impl IsA<Widget>,
+        property_name: &str,
+    ) -> V {
+        let value = self.child_property_value(child, property_name);
+        value
+            .get_owned::<V>()
+            .expect("Failed to get value of container")
+    }
+
+    fn child_set_property(
+        &self,
+        child: &impl IsA<Widget>,
+        property_name: &str,
+        value: &dyn ToValue,
+    ) {
+        unsafe {
+            let container_class = glib::Class::<Container>::from_type(O::static_type()).unwrap();
+            let pspec: Option<glib::ParamSpec> =
+                from_glib_none(ffi::gtk_container_class_find_child_property(
+                    container_class.as_ref() as *const _ as *const glib::gobject_ffi::GObjectClass,
+                    property_name.to_glib_none().0,
+                ));
+            let pspec = pspec.unwrap_or_else(|| {
+                panic!("The Container property '{}' doesn't exists", property_name)
+            });
+
+            if !pspec.flags().contains(glib::ParamFlags::WRITABLE)
+                || !pspec.flags().contains(glib::ParamFlags::READWRITE)
+            {
+                panic!(
+                    "The Container property '{}' is not writeable",
+                    property_name
+                );
+            }
+
+            assert!(
+                pspec.value_type().is_a(value.value_type()),
+                "The Container property '{}' is value is of wrong type. Expected '{}' but got '{}'",
+                property_name,
+                pspec.value_type(),
+                value.value_type()
+            );
+
+            ffi::gtk_container_child_set_property(
+                self.as_ref().to_glib_none().0,
+                child.as_ref().to_glib_none().0,
+                property_name.to_glib_none().0,
+                value.to_value().to_glib_none().0,
+            );
+        }
+    }
+}

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -72,6 +72,7 @@ mod clipboard;
 mod color_button;
 mod color_chooser;
 mod combo_box;
+mod container;
 mod dialog;
 mod drag_context;
 mod entry;

--- a/gtk/src/prelude.rs
+++ b/gtk/src/prelude.rs
@@ -25,6 +25,7 @@ pub use crate::cell_renderer_pixbuf::CellRendererPixbufExtManual;
 pub use crate::color_button::ColorButtonExtManual;
 pub use crate::color_chooser::ColorChooserExtManual;
 pub use crate::combo_box::ComboBoxExtManual;
+pub use crate::container::ContainerExtManual;
 pub use crate::dialog::DialogExtManual;
 pub use crate::drag_context::DragContextExtManual;
 pub use crate::entry::EntryExtManual;

--- a/gtk/sys/src/manual.rs
+++ b/gtk/sys/src/manual.rs
@@ -3,3 +3,14 @@
 pub mod xlib {
     pub type Window = i32;
 }
+
+//=========================================================================
+// GtkContainerClass
+//=========================================================================
+
+extern "C" {
+    pub fn gtk_container_class_find_child_property(
+        cclass: *const gobject::GObjectClass,
+        property_name: *const libc::c_char,
+    ) -> *mut gobject::GParamSpec;
+}


### PR DESCRIPTION
It requires a manual implementation to check if the property exists
and is readable/writeable and also of the correct type.
Fixes #664