### PR TITLE
Point to git 0.15 versions of the gtk-rs-core dependencies

### DIFF
--- a/atk/Cargo.toml
+++ b/atk/Cargo.toml
@@ -33,7 +33,7 @@ features = ["dox"]
 libc = "0.2"
 bitflags = "1.0"
 ffi = {package = "atk-sys", path = "sys", version = "0.15.1"}
-glib = "0.15.1"
+glib = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/atk/sys/Cargo.toml
+++ b/atk/sys/Cargo.toml
@@ -7,10 +7,14 @@ libc = "0.2"
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gobject]
 package = "gobject-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dev-dependencies]
 shell-words = "1.0.0"

--- a/atk/sys/Cargo.toml
+++ b/atk/sys/Cargo.toml
@@ -43,10 +43,8 @@ repository = "https://github.com/gtk-rs/gtk3-rs"
 version = "0.15.1"
 edition = "2021"
 rust-version = "1.56"
-
 [package.metadata.docs.rs]
 features = ["dox"]
-
 [package.metadata.system-deps.atk]
 name = "atk"
 version = "2.18"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,6 +12,8 @@ once_cell = "1.2.0"
 
 [dependencies.glib]
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gtk]
 path = "../gtk"
@@ -20,15 +22,21 @@ version = "0.15.1"
 [dependencies.pangocairo]
 optional = true
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.cairo]
 package = "cairo-rs"
 features = ["png"]
 optional = true
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [build-dependencies.gio]
+version = "0.15.1"
 git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [[bin]]
 name = "accessibility"

--- a/gdk/Cargo.toml
+++ b/gdk/Cargo.toml
@@ -31,11 +31,11 @@ features = ["dox"]
 libc = "0.2"
 bitflags = "1.0"
 ffi = {package = "gdk-sys", path = "sys", version = "0.15.1"}
-cairo-rs = "0.15.1"
-gdk-pixbuf = "0.15.1"
-gio = "0.15.1"
-glib = "0.15.1"
-pango = "0.15.1"
+cairo-rs = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+gdk-pixbuf = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+gio = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+glib = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+pango = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gdk/sys/Cargo.toml
+++ b/gdk/sys/Cargo.toml
@@ -8,26 +8,38 @@ libc = "0.2"
 [dependencies.cairo]
 package = "cairo-sys-rs"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gdk-pixbuf]
 package = "gdk-pixbuf-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gio]
 package = "gio-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gobject]
 package = "gobject-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.pango]
 package = "pango-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dev-dependencies]
 shell-words = "1.0.0"

--- a/gdk/sys/Cargo.toml
+++ b/gdk/sys/Cargo.toml
@@ -67,10 +67,8 @@ repository = "https://github.com/gtk-rs/gtk3-rs"
 version = "0.15.1"
 edition = "2021"
 rust-version = "1.56"
-
 [package.metadata.docs.rs]
 features = ["dox"]
-
 [package.metadata.system-deps.gdk_3_0]
 name = "gdk-3.0"
 version = "3.18"

--- a/gdkwayland/Cargo.toml
+++ b/gdkwayland/Cargo.toml
@@ -24,7 +24,7 @@ features = ["dox"]
 [dependencies]
 ffi = {path = "./sys", package = "gdkwayland-sys", version = "0.15.1"}
 gdk = {path = "../gdk", version = "0.15.1"}
-glib = "0.15.1"
+glib = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 libc = "0.2"
 wayland-client = {version = "0.29", features = ["use_system_lib"]}
 

--- a/gdkwayland/sys/Cargo.toml
+++ b/gdkwayland/sys/Cargo.toml
@@ -25,10 +25,14 @@ libc = "0.2"
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gobject]
 package = "gobject-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gdk]
 package = "gdk-sys"

--- a/gdkx11/Cargo.toml
+++ b/gdkx11/Cargo.toml
@@ -32,9 +32,9 @@ features = ["dox"]
 libc = "0.2"
 x11 = "2.18"
 ffi = {package = "gdkx11-sys", path = "sys", version = "0.15.1"}
-glib = "0.15.1"
+glib = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 gdk = {path = "../gdk", version = "0.15.1"}
-gio = "0.15.1"
+gio = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gdkx11/sys/Cargo.toml
+++ b/gdkx11/sys/Cargo.toml
@@ -39,11 +39,15 @@ version = "0.15.1"
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.cairo]
 package = "cairo-sys-rs"
 optional = true
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [build-dependencies]
 system-deps = "6"

--- a/gdkx11/sys/Cargo.toml
+++ b/gdkx11/sys/Cargo.toml
@@ -10,10 +10,8 @@ version = "0.15.1"
 build = "build.rs"
 edition = "2021"
 rust-version = "1.56"
-
 [package.metadata.docs.rs]
 features = ["dox"]
-
 [package.metadata.system-deps.gdk_x11_3_0]
 name = "gdk-x11-3.0"
 version = "3.18"

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -50,12 +50,12 @@ once_cell = "1.0"
 atk = {path = "../atk", version = "0.15.1"}
 ffi = {package = "gtk-sys", path = "sys", version = "0.15.1"}
 gtk3-macros = {path = "../gtk3-macros", version = "0.15.1"}
-cairo-rs = "0.15.1"
-gio = "0.15.1"
-glib = "0.15.1"
+cairo-rs = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+gio = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+glib = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 gdk = {path = "../gdk", version = "0.15.1"}
-gdk-pixbuf = "0.15.1"
-pango = "0.15.1"
+gdk-pixbuf = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+pango = { version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gtk/sys/Cargo.toml
+++ b/gtk/sys/Cargo.toml
@@ -61,14 +61,20 @@ libc = "0.2"
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gobject]
 package = "gobject-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gio]
 package = "gio-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.atk]
 package = "atk-sys"
@@ -78,6 +84,8 @@ version = "0.15.1"
 [dependencies.gdk-pixbuf]
 package = "gdk-pixbuf-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gdk]
 package = "gdk-sys"
@@ -87,10 +95,14 @@ version = "0.15.1"
 [dependencies.pango]
 package = "pango-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.cairo]
 package = "cairo-sys-rs"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [build-dependencies]
 system-deps = "6"

--- a/gtk/sys/Cargo.toml
+++ b/gtk/sys/Cargo.toml
@@ -11,10 +11,8 @@ license = "MIT"
 repository = "https://github.com/gtk-rs/gtk3-rs"
 edition = "2021"
 rust-version = "1.56"
-
 [package.metadata.docs.rs]
 features = ["dox"]
-
 [package.metadata.system-deps."gtk+_3_0"]
 name = "gtk+-3.0"
 version = "3.18"


### PR DESCRIPTION
This makes sure we're building against the latest 0.15 versions while
still being able to publish to crates.io.