### PR TITLE
gtk/{Text,Tree}Iter: derive Debug

### DIFF
--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -2276,6 +2276,8 @@ manual_traits = ["TextBufferExtManual"]
 name = "Gtk.TextIter"
 status = "generate"
 boxed_inline = true
+    [[object.derive]]
+    name = "Debug"
     [[object.function]]
     name = "get_attributes"
     manual = true
@@ -2394,6 +2396,8 @@ generate_builder = true
 name = "Gtk.TreeIter"
 status = "generate"
 boxed_inline = true
+    [[object.derive]]
+    name = "Debug"
 
 [[object]]
 name = "Gtk.TreeModel"

--- a/gtk/src/auto/text_iter.rs
+++ b/gtk/src/auto/text_iter.rs
@@ -12,6 +12,7 @@ use glib::translate::*;
 use std::cmp;
 
 glib::wrapper! {
+    #[derive(Debug)]
     pub struct TextIter(BoxedInline<ffi::GtkTextIter>);
 
     match fn {

--- a/gtk/src/auto/tree_iter.rs
+++ b/gtk/src/auto/tree_iter.rs
@@ -5,6 +5,7 @@
 use glib::translate::*;
 
 glib::wrapper! {
+    #[derive(Debug)]
     pub struct TreeIter(BoxedInline<ffi::GtkTreeIter>);
 
     match fn {


### PR DESCRIPTION
So that a `struct` using these types can also auto derive `Debug`.

Another solution could be to add a `Debug` `impl` in manual code,
but since these are iterators, there's not much we can show.

Other `boxed_inline` candidates in `gtk-rs-core` and `gtk3-rs` use manual `Debug` `impl` AFAICT.