### PR TITLE
gtk: Use `u32` as underlying type for the `stock-size` property of `CellRendererPixbuf`

### DIFF
--- a/gtk/src/cell_renderer_pixbuf.rs
+++ b/gtk/src/cell_renderer_pixbuf.rs
@@ -14,10 +14,10 @@ pub trait CellRendererPixbufExtManual: 'static {
 
 impl<O: IsA<CellRendererPixbuf> + IsA<glib::object::Object>> CellRendererPixbufExtManual for O {
     fn property_stock_size(&self) -> IconSize {
-        unsafe { from_glib(self.property::<i32>("stock-size")) }
+        unsafe { from_glib(self.property::<u32>("stock-size") as i32) }
     }
 
     fn set_property_stock_size(&self, stock_size: IconSize) {
-        self.set_property("stock-size", &stock_size.into_glib());
+        self.set_property("stock-size", stock_size.into_glib() as u32);
     }
 }

--- a/gtk/src/cell_renderer_pixbuf.rs
+++ b/gtk/src/cell_renderer_pixbuf.rs
@@ -7,17 +7,17 @@ use glib::translate::*;
 
 pub trait CellRendererPixbufExtManual: 'static {
     #[doc(alias = "get_property_stock_size")]
-    fn property_stock_size(&self) -> IconSize;
+    fn stock_size(&self) -> IconSize;
 
-    fn set_property_stock_size(&self, stock_size: IconSize);
+    fn set_stock_size(&self, stock_size: IconSize);
 }
 
 impl<O: IsA<CellRendererPixbuf> + IsA<glib::object::Object>> CellRendererPixbufExtManual for O {
-    fn property_stock_size(&self) -> IconSize {
+    fn stock_size(&self) -> IconSize {
         unsafe { from_glib(self.property::<u32>("stock-size") as i32) }
     }
 
-    fn set_property_stock_size(&self, stock_size: IconSize) {
+    fn set_stock_size(&self, stock_size: IconSize) {
         self.set_property("stock-size", stock_size.into_glib() as u32);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gtk-rs/gtk3-rs/issues/717

----

Only the first commit should be backported.