### PR TITLE
Handle empty slices correctly

### DIFF
--- a/gdk/src/visual.rs
+++ b/gdk/src/visual.rs
@@ -13,7 +13,11 @@ impl Visual {
 
         unsafe {
             ffi::gdk_query_depths(&mut ptr, &mut count);
-            Vec::from(slice::from_raw_parts(ptr as *const i32, count as usize))
+            if ptr.is_null() || count == 0 {
+                vec![]
+            } else {
+                Vec::from(slice::from_raw_parts(ptr as *const i32, count as usize))
+            }
         }
     }
 }

--- a/gtk/src/signal.rs
+++ b/gtk/src/signal.rs
@@ -115,7 +115,9 @@ mod editable {
     ) where
         T: IsA<Editable>,
     {
-        let buf = if new_text_length != -1 {
+        let buf = if new_text_length == 0 {
+            &[]
+        } else if new_text_length != -1 {
             slice::from_raw_parts(new_text as *mut c_uchar, new_text_length as usize)
         } else {
             CStr::from_ptr(new_text).to_bytes()

--- a/gtk/src/text_buffer.rs
+++ b/gtk/src/text_buffer.rs
@@ -223,10 +223,16 @@ impl<O: IsA<TextBuffer>> TextBufferExtManual for O {
             let f: &F = &*(f as *const F);
             let mut location_copy = from_glib_none(location);
 
+            let text = if len <= 0 {
+                &[]
+            } else {
+                slice::from_raw_parts(text as *const u8, len as usize)
+            };
+
             f(
                 TextBuffer::from_glib_borrow(this).unsafe_cast_ref(),
                 &mut location_copy,
-                str::from_utf8(slice::from_raw_parts(text as *const u8, len as usize)).unwrap(),
+                str::from_utf8(text).unwrap(),
             );
 
             *location = *location_copy.to_glib_none().0;

--- a/gtk/src/tree_path.rs
+++ b/gtk/src/tree_path.rs
@@ -14,7 +14,7 @@ impl TreePath {
                 mut_override(self.to_glib_none().0),
                 &mut count,
             );
-            if ptr.is_null() {
+            if ptr.is_null() || count == 0 {
                 vec![]
             } else {
                 slice::from_raw_parts(ptr, count as usize).to_owned()


### PR DESCRIPTION
Passing `NULL` to `slice::from_raw_parts` is invalid.