### PR TITLE
gtk: Add an `unsafe-assume-initialized` feature

### DIFF
--- a/gdk/Cargo.toml
+++ b/gdk/Cargo.toml
@@ -21,6 +21,7 @@ name = "gdk"
 [features]
 v3_24 = ["ffi/v3_24"]
 dox = ["ffi/dox", "glib/dox", "gio/dox", "gdk-pixbuf/dox", "cairo-rs/dox", "pango/dox"]
+unsafe-assume-initialized = []
 
 [package.metadata.docs.rs]
 features = ["dox"]

--- a/gdk/src/rt.rs
+++ b/gdk/src/rt.rs
@@ -43,14 +43,22 @@ macro_rules! assert_not_initialized {
 #[inline]
 pub fn is_initialized() -> bool {
     skip_assert_initialized!();
-    INITIALIZED.load(Ordering::Acquire)
+    if cfg!(not(feature = "unsafe-assume-initialized")) {
+        INITIALIZED.load(Ordering::Acquire)
+    } else {
+        true
+    }
 }
 
 /// Returns `true` if GDK has been initialized and this is the main thread.
 #[inline]
 pub fn is_initialized_main_thread() -> bool {
     skip_assert_initialized!();
-    IS_MAIN_THREAD.with(|c| c.get())
+    if cfg!(not(feature = "unsafe-assume-initialized")) {
+        IS_MAIN_THREAD.with(|c| c.get())
+    } else {
+        true
+    }
 }
 
 /// Informs this crate that GDK has been initialized and the current thread is the main one.

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -29,6 +29,7 @@ v3_24_11 = ["v3_24_9", "ffi/v3_24_11"]
 v3_24_30 = ["v3_24_11", "ffi/v3_24_30"]
 dox = ["gdk/dox", "ffi/dox"]
 gio_v2_58 = ["gio/v2_58"]
+unsafe-assume-initialized = []
 
 [package.metadata.docs.rs]
 features = ["dox"]

--- a/gtk/src/rt.rs
+++ b/gtk/src/rt.rs
@@ -47,14 +47,22 @@ macro_rules! assert_not_initialized {
 #[inline]
 pub fn is_initialized() -> bool {
     skip_assert_initialized!();
-    INITIALIZED.load(Ordering::Acquire)
+    if cfg!(not(feature = "unsafe-assume-initialized")) {
+        INITIALIZED.load(Ordering::Acquire)
+    } else {
+        true
+    }
 }
 
 /// Returns `true` if GTK has been initialized and this is the main thread.
 #[inline]
 pub fn is_initialized_main_thread() -> bool {
     skip_assert_initialized!();
-    IS_MAIN_THREAD.with(|c| c.get())
+    if cfg!(not(feature = "unsafe-assume-initialized")) {
+        IS_MAIN_THREAD.with(|c| c.get())
+    } else {
+        true
+    }
 }
 
 /// Informs this crate that GTK has been initialized and the current thread is the main one.


### PR DESCRIPTION
This is useful for building a `cdylib`/`staticlib` with C ABI bindings, where `gtk_init()` will be called from outside Rust.