### PR TITLE
Don't checkout submodules by default

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.57.0"
+          - "1.63.0"
         conf:
           - { name: "atk", features: "v2_34", test_sys: false } # disable for now, until we get 2.38 on the docker image
           - { name: "gdk", features: "v3_24", test_sys: true }
@@ -98,7 +98,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.57.0"
+          - "1.63.0"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,10 +139,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          set-safe-directory: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - run: git submodule update --checkout
       - run: python3 generator.py
       - run: git diff --exit-code

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ name: docs
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: build
     container:
       image: ghcr.io/gtk-rs/gtk3-rs/gtk3:latest
@@ -23,14 +23,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          set-safe-directory: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
           components: rustfmt
-      - working-directory: gir
-        run: cargo build --release
+      - run: git submodule update --checkout
       - run: cargo install rustdoc-stripper
       - run: python3 ./generator.py --embed-docs --yes ./
       - run: git clone https://gitlab.gnome.org/World/Rust/gir-rustdoc/ # checkout action doesn't support random urls

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "gir"]
 	path = gir
 	url = https://github.com/gtk-rs/gir
+	update = none
 [submodule "gir-files"]
 	path = gir-files
 	url = https://github.com/gtk-rs/gir-files
+	update = none

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ file as follows:
 $ python3 generator.py
 ```
 
+If you didn't do so yet, please check out all the submodules before via
+
+```bash
+$ git submodule update --checkout
+```
+
 ## Development
 
 This repository is mostly split into two branches: `master` and `crate`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ information about each crate, please refer to their `README.md` file in their di
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.57.0`.
+Currently, the minimum supported Rust version is `1.63.0`.
 
 ## Documentation
 

--- a/atk/Cargo.toml
+++ b/atk/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 
 [lib]
 name = "atk"

--- a/atk/README.md
+++ b/atk/README.md
@@ -9,7 +9,7 @@ ATK __2.28__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.57.0`.
+Currently, the minimum supported Rust version is `1.63.0`.
 
 ## Documentation
 

--- a/atk/sys/Cargo.toml
+++ b/atk/sys/Cargo.toml
@@ -38,7 +38,7 @@ name = "atk-sys"
 repository = "https://github.com/gtk-rs/gtk3-rs"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.atk]

--- a/gdk/Cargo.toml
+++ b/gdk/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 
 [lib]
 name = "gdk"

--- a/gdk/README.md
+++ b/gdk/README.md
@@ -9,7 +9,7 @@ GDK __3.22__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.57.0`.
+Currently, the minimum supported Rust version is `1.63.0`.
 
 ## Documentation
 

--- a/gdk/sys/Cargo.toml
+++ b/gdk/sys/Cargo.toml
@@ -52,7 +52,7 @@ name = "gdk-sys"
 repository = "https://github.com/gtk-rs/gtk3-rs"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.gdk_3_0]

--- a/gdkwayland/Cargo.toml
+++ b/gdkwayland/Cargo.toml
@@ -10,7 +10,7 @@ name = "gdkwayland"
 readme = "README.md"
 repository = "https://github.com/gtk-rs/gtk3-rs"
 version = "0.16.0"
-rust-version = "1.57"
+rust-version = "1.63"
 
 [features]
 v3_24 = ["ffi/v3_24", "gdk/v3_24"]

--- a/gdkwayland/README.md
+++ b/gdkwayland/README.md
@@ -9,7 +9,7 @@ GDK3-Wayland __3.22__ is the lowest supported version for the underlying library
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.57.0`.
+Currently, the minimum supported Rust version is `1.63.0`.
 
 ## Documentation
 

--- a/gdkwayland/sys/Cargo.toml
+++ b/gdkwayland/sys/Cargo.toml
@@ -8,7 +8,7 @@ name = "gdkwayland-sys"
 repository = "https://github.com/gtk-rs/gtk3-rs"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 
 [lib]
 name = "gdk_wayland_sys"

--- a/gdkx11/Cargo.toml
+++ b/gdkx11/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 
 [lib]
 name = "gdkx11"

--- a/gdkx11/README.md
+++ b/gdkx11/README.md
@@ -9,7 +9,7 @@ GDKX11 __3.22__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.57.0`.
+Currently, the minimum supported Rust version is `1.63.0`.
 
 ## Documentation
 

--- a/gdkx11/sys/Cargo.toml
+++ b/gdkx11/sys/Cargo.toml
@@ -9,7 +9,7 @@ name = "gdkx11-sys"
 version = "0.16.0"
 build = "build.rs"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.gdk_x11_3_0]

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 
 [lib]
 name = "gtk"

--- a/gtk/README.md
+++ b/gtk/README.md
@@ -9,7 +9,7 @@ GTK __3.22.30__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.57.0`.
+Currently, the minimum supported Rust version is `1.63.0`.
 
 ## Building
 

--- a/gtk/sys/Cargo.toml
+++ b/gtk/sys/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["gtk", "ffi", "gtk-rs", "gnome"]
 license = "MIT"
 repository = "https://github.com/gtk-rs/gtk3-rs"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps."gtk+_3_0"]

--- a/gtk3-macros/Cargo.toml
+++ b/gtk3-macros/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
     "gir-files/*",
     "src/composite_template.ui"
 ]
-rust-version = "1.57"
+rust-version = "1.63"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This makes sure that cargo does not clone and checkout all the
submodules if pointing to this repository as a git dependency.

To checkout the submodules `git submodule update --checkout` can be
used.