### PR TITLE
Activate dox feature wherever possible

### DIFF
--- a/atk/Cargo.toml
+++ b/atk/Cargo.toml
@@ -10,9 +10,7 @@ readme = "README.md"
 version = "0.16.0"
 keywords = ["atk", "gtk-rs", "gnome", "accessibility"]
 repository = "https://github.com/gtk-rs/gtk3-rs"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["gir-files/*"]
 edition = "2021"
 rust-version = "1.63"
 
@@ -20,7 +18,7 @@ rust-version = "1.63"
 name = "atk"
 
 [features]
-dox = ["ffi/dox"]
+dox = ["ffi/dox", "glib/dox"]
 v2_30 = ["ffi/v2_30"]
 v2_32 = ["v2_30", "ffi/v2_32"]
 v2_34 = ["v2_32", "ffi/v2_34"]

--- a/gdkwayland/Cargo.toml
+++ b/gdkwayland/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.63"
 [features]
 v3_24 = ["ffi/v3_24", "gdk/v3_24"]
 v3_24_22 = ["v3_24", "ffi/v3_24_22"]
-dox = ["ffi/dox"]
+dox = ["ffi/dox", "gdk/dox", "glib/dox"]
 
 [package.metadata.docs.rs]
 features = ["dox"]
@@ -25,7 +25,7 @@ ffi = { path = "./sys", package = "gdkwayland-sys" }
 gdk = { path = "../gdk" }
 glib = { git = "https://github.com/gtk-rs/gtk-rs-core" }
 libc = "0.2"
-wayland-client = {version = "0.29", features = ["use_system_lib"]}
+wayland-client = { version = "0.29", features = ["use_system_lib"] }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gdkx11/Cargo.toml
+++ b/gdkx11/Cargo.toml
@@ -9,9 +9,7 @@ documentation = "https://gtk-rs.org/gtk3-rs/stable/latest/docs/gdkx11/"
 version = "0.16.0"
 description = "Rust bindings for the GDK X11 library"
 repository = "https://github.com/gtk-rs/gtk3-rs"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["gir-files/*"]
 edition = "2021"
 rust-version = "1.63"
 
@@ -19,7 +17,7 @@ rust-version = "1.63"
 name = "gdkx11"
 
 [features]
-dox = ["gdk/dox", "ffi/dox"]
+dox = ["x11/dox", "glib/dox", "gdk/dox", "gio/dox", "ffi/dox"]
 v3_24 = ["ffi/v3_24_2"]
 
 [package.metadata.docs.rs]

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -11,9 +11,7 @@ version = "0.16.0"
 keywords = ["gtk", "gtk-rs", "gnome", "GUI"]
 repository = "https://github.com/gtk-rs/gtk3-rs"
 build = "build.rs"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["gir-files/*"]
 edition = "2021"
 rust-version = "1.63"
 
@@ -27,7 +25,16 @@ v3_24_8 = ["v3_24_1", "ffi/v3_24_8"]
 v3_24_9 = ["v3_24_8", "ffi/v3_24_9"]
 v3_24_11 = ["v3_24_9", "ffi/v3_24_11"]
 v3_24_30 = ["v3_24_11", "ffi/v3_24_30"]
-dox = ["gdk/dox", "ffi/dox"]
+dox = [
+    "ffi/dox",
+    "atk/dox",
+    "cairo-rs/dox",
+    "gio/dox",
+    "glib/dox",
+    "gdk/dox",
+    "gdk-pixbuf/dox",
+    "pango/dox",
+]
 gio_v2_58 = ["gio/v2_58"]
 unsafe-assume-initialized = []
 
@@ -45,7 +52,7 @@ futures-channel = "0.3"
 once_cell = "1.0"
 atk = { path = "../atk" }
 ffi = { package = "gtk-sys", path = "sys" }
-gtk3-macros =  { path = "../gtk3-macros" }
+gtk3-macros = { path = "../gtk3-macros" }
 cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs-core" }
 gio = { git = "https://github.com/gtk-rs/gtk-rs-core" }
 glib = { git = "https://github.com/gtk-rs/gtk-rs-core" }


### PR DESCRIPTION
Analogous to: https://github.com/gtk-rs/gtk-rs-core/pull/778

Whenever a crate is published on crates.io, its documentation is automatically built on docs.rs regardless of the documentation field in the Cargo.toml file. On docs.rs it is possible to look at all previous versions. This is why there is value in having working builds on docs.rs. Having broken builds on docs.rs also prevents crates using that library from providing their own documentation on docs.rs. I enabled the dox feature wherever it is available to ensure the docs always build, even if the dependencies are not available.