### PR TITLE
Skip init assertion for gdk::set_allowed_backends

### DIFF
--- a/gdk/Gir.toml
+++ b/gdk/Gir.toml
@@ -220,6 +220,9 @@ status = "generate"
     [[object.function]]
     name = "init_check"
     ignore = true # TODO: manually implement
+    [[object.function]]
+    name = "set_allowed_backends"
+    assertion = "skip"
 
 [[object]]
 name = "Gdk.Cursor"

--- a/gdk/src/auto/functions.rs
+++ b/gdk/src/auto/functions.rs
@@ -361,7 +361,7 @@ pub fn selection_send_notify_for_display(
 
 #[doc(alias = "gdk_set_allowed_backends")]
 pub fn set_allowed_backends(backends: &str) {
-    assert_initialized_main_thread!();
+    skip_assert_initialized!();
     unsafe {
         ffi::gdk_set_allowed_backends(backends.to_glib_none().0);
     }


### PR DESCRIPTION
To my understanding `gdk::set_allowed_backends()` should be called (when needed) before the `init()`  

https://docs.gtk.org/gdk3/func.set_allowed_backends.html
> This call must happen prior to gdk_display_open(), gtk_init(), gtk_init_with_args() or gtk_init_check() in order to take effect.

The way I added the assertion skip might not be the way intended.
Please let me know.
