### PR TITLE
gtk3-macros: enable default features of syn

### DIFF
--- a/gtk3-macros/Cargo.toml
+++ b/gtk3-macros/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1.0"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", default-features = false, features = ["full"] }
+syn = { version = "1.0", features = ["full"] }
 proc-macro-crate = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The code in this crate uses features of "syn" which are only present
when the default features are enabled. This previously worked "by
accident" because other crates in the dependency tree pulled in the
"default" feature of syn, but these crates have started moving to
syn v2, so this is no longer the case.
