### PR TITLE
Upgrade syn to 2.0

### DIFF
--- a/gtk3-macros/Cargo.toml
+++ b/gtk3-macros/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1.0"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 proc-macro-crate = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
There's also a `NestedMeta` API in syn 2.0, but it's callback based for some reason and I'm much more familiar with the custom parsing API. The error messages should be of similar quality to before, on average.