### PR TITLE
More fixes for docsrs attribute

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: -p atk -p atk-sys -p gdk -p gdk-sys -p gdkx11 -p gdkx11-sys -p gtk -p gtk3-macros -p gtk-sys -p gdkwayland -p gdkwayland-sys --no-deps
+          args: -p atk -p atk-sys -p gdk -p gdk-sys -p gdkx11 -p gdkx11-sys -p gtk -p gtk3-macros -p gtk-sys -p gdkwayland -p gdkwayland-sys --no-deps --all-features
       - run: echo "RELEASE=$(echo '${{ github.event.release.tag_name }}' | grep -Po '(\d+)\.(\d+)')" >> ${GITHUB_ENV}
       - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" == "release" ]; then echo 'stable/${{ env.RELEASE }}'; else echo 'git'; fi)" >> ${GITHUB_ENV}
       - name: Grab gtk-rs LOGO

--- a/gdkwayland/src/wayland_window.rs
+++ b/gdkwayland/src/wayland_window.rs
@@ -95,7 +95,7 @@ impl WaylandWindow {
         }
     }
 
-    #[cfg(any(feature = "v3_24_22", docsrs))]
+    #[cfg(feature = "v3_24_22")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v3_24_22")))]
     #[doc(alias = "gdk_wayland_window_set_application_id")]
     pub fn set_application_id(&self, application_id: &str) -> bool {
@@ -112,7 +112,7 @@ impl WaylandWindow {
         unsafe { ffi::gdk_wayland_window_announce_csd(self.to_glib_none().0) }
     }
 
-    #[cfg(any(feature = "v3_24", docsrs))]
+    #[cfg(feature = "v3_24")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
     #[doc(alias = "gdk_wayland_window_announce_ssd")]
     pub fn announce_ssd(&self) {

--- a/gdkwayland/sys/src/lib.rs
+++ b/gdkwayland/sys/src/lib.rs
@@ -71,7 +71,7 @@ extern "C" {
         parent_handle: *const c_char,
     ) -> glib::gboolean;
 
-    #[cfg(any(feature = "v3_24_22", docsrs))]
+    #[cfg(feature = "v3_24_22")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v3_24_22")))]
     pub fn gdk_wayland_window_set_application_id(
         window: *mut GdkWaylandWindow,
@@ -80,18 +80,18 @@ extern "C" {
 
     pub fn gdk_wayland_window_announce_csd(window: *mut GdkWaylandWindow);
 
-    #[cfg(any(feature = "v3_24", docsrs))]
+    #[cfg(feature = "v3_24")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
     pub fn gdk_wayland_window_announce_ssd(window: *mut GdkWaylandWindow);
 
-    #[cfg(any(feature = "v3_24", docsrs))]
+    #[cfg(feature = "v3_24")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
     pub fn gdk_wayland_window_add_frame_callback_surface(
         window: *mut GdkWaylandWindow,
         surface: glib::gconstpointer,
     );
 
-    #[cfg(any(feature = "v3_24", docsrs))]
+    #[cfg(feature = "v3_24")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
     pub fn gdk_wayland_window_remove_frame_callback_surface(
         window: *mut GdkWaylandWindow,

--- a/gtk/src/file_chooser.rs
+++ b/gtk/src/file_chooser.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::FileChooser;
-#[cfg(any(feature = "v3_22", docsrs))]
+#[cfg(feature = "v3_22")]
 #[cfg_attr(docsrs, doc(cfg(feature = "v3_22")))]
 use glib::translate::*;
 use glib::IsA;
@@ -14,7 +14,7 @@ mod sealed {
 }
 
 pub trait FileChooserExtManual: IsA<FileChooser> + sealed::Sealed + 'static {
-    #[cfg(any(feature = "v3_22", docsrs))]
+    #[cfg(feature = "v3_22")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v3_22")))]
     #[doc(alias = "gtk_file_chooser_add_choice")]
     fn add_choice(&self, id: &str, label: &str, options: &[(&str, &str)]) {

--- a/gtk/src/gesture_stylus.rs
+++ b/gtk/src/gesture_stylus.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-#[cfg(any(feature = "v3_24", docsrs))]
+#[cfg(feature = "v3_24")]
 use crate::GestureStylus;
 use gdk::AxisUse;
 use glib::object::IsA;
@@ -12,7 +12,7 @@ mod sealed {
 }
 
 pub trait GestureStylusExtManual: IsA<GestureStylus> + sealed::Sealed + 'static {
-    #[cfg(any(feature = "v3_24", docsrs))]
+    #[cfg(feature = "v3_24")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
     #[doc(alias = "gtk_gesture_stylus_get_axes")]
     #[doc(alias = "get_axes")]

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -86,7 +86,7 @@ mod file_filter_info;
 mod fixed;
 mod flow_box;
 mod functions;
-#[cfg(any(feature = "v3_24", docsrs))]
+#[cfg(feature = "v3_24")]
 mod gesture_stylus;
 mod im_context_simple;
 mod image;

--- a/gtk/src/prelude.rs
+++ b/gtk/src/prelude.rs
@@ -33,7 +33,7 @@ pub use crate::entry_completion::EntryCompletionExtManual;
 pub use crate::file_chooser::FileChooserExtManual;
 pub use crate::fixed::FixedExtManual;
 pub use crate::flow_box::FlowBoxExtManual;
-#[cfg(any(feature = "v3_24", docsrs))]
+#[cfg(feature = "v3_24")]
 pub use crate::gesture_stylus::GestureStylusExtManual;
 pub use crate::im_context_simple::IMContextSimpleExtManual;
 pub use crate::image::ImageExtManual;

--- a/gtk/src/subclass/mod.rs
+++ b/gtk/src/subclass/mod.rs
@@ -25,10 +25,10 @@ pub mod icon_view;
 pub mod list_box;
 pub mod list_box_row;
 pub mod menu_button;
-#[cfg(any(gdk_backend = "x11", docsrs))]
+#[cfg(gdk_backend = "x11")]
 pub mod plug;
 pub mod scrolled_window;
-#[cfg(any(gdk_backend = "x11", docsrs))]
+#[cfg(gdk_backend = "x11")]
 pub mod socket;
 pub mod stack;
 pub mod toggle_button;
@@ -67,10 +67,10 @@ pub mod prelude {
     pub use super::list_box::{ListBoxImpl, ListBoxImplExt};
     pub use super::list_box_row::{ListBoxRowImpl, ListBoxRowImplExt};
     pub use super::menu_button::MenuButtonImpl;
-    #[cfg(any(gdk_backend = "x11", docsrs))]
+    #[cfg(gdk_backend = "x11")]
     pub use super::plug::{PlugImpl, PlugImplExt};
     pub use super::scrolled_window::{ScrolledWindowImpl, ScrolledWindowImplExt};
-    #[cfg(any(gdk_backend = "x11", docsrs))]
+    #[cfg(gdk_backend = "x11")]
     pub use super::socket::{SocketImpl, SocketImplExt};
     pub use super::stack::StackImpl;
     pub use super::toggle_button::ToggleButtonImpl;


### PR DESCRIPTION
This PR is analogous to https://github.com/gtk-rs/gtk-rs-core/pull/1078.

Without it, the builds will likely break on docs.rs, which would leave may crates relying on gtk3-rs related crates without working docs.