### PR TITLE
Workflow updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,10 +49,9 @@ jobs:
           - { name: "gtk", features: "v3_24_9", test_sys: false }
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - uses: actions/checkout@v7
         with:
           repository: gtk-rs/checker
@@ -122,10 +121,9 @@ jobs:
           - "1.92"
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       # gtk3-macros
       - name: "gtk3-macros: tests"
         run: xvfb-run --auto-servernum cargo test --manifest-path gtk3-macros/Cargo.toml
@@ -142,16 +140,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   generator:
     name: regen check
@@ -161,11 +154,9 @@ jobs:
         with:
           submodules: recursive
           set-safe-directory: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - run: git submodule update --checkout
       - run: python3 generator.py
       - run: git diff --exit-code

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,29 @@
 on:
   push:
     branches: [master]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/CI.yml"
+      - "atk/**"
+      - "examples/**"
+      - "gdk/**"
+      - "gdkwayland/**"
+      - "gdkx11/**"
+      - "gtk/**"
+      - "gtk3-macros/**"
   pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/CI.yml"
+      - "atk/**"
+      - "examples/**"
+      - "gdk/**"
+      - "gdkwayland/**"
+      - "gdkx11/**"
+      - "gtk/**"
+      - "gtk3-macros/**"
   workflow_dispatch:
 
 name: CI

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,52 @@
+name: Auto updates
+
+on:
+  repository_dispatch:
+    types: [internal-merge-event]
+  workflow_dispatch:
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git submodule update --checkout
+
+      - name: Update Git submodules
+        run: |
+          cd ./gir && git fetch --all && git reset --hard origin/main && cd ../
+          git add .
+          git diff --cached --exit-code || git commit -m "Update gir"
+          python generator.py
+          git add .
+          git diff --cached --exit-code || git commit -m "Regenerate with latest gir"
+          cd ./gir-files && git fetch --all && git reset --hard origin/main && cd ../
+          git add .
+          git diff --cached --exit-code || git commit -m "Update gir-files"
+          python generator.py
+          git add .
+          git diff --cached --exit-code || git commit -m "Regenerate with latest gir-files"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "auto-pr-branch"
+          title: "Automated PR: Changes from updating gir/gir-files"
+          body: "This PR contains auto-generated changes after a merge in the external gir-files repository."
+          commit-message: "Auto-generated changes from updating gir/gir-files"
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ name: docs
 
 jobs:
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: build
     container:
       image: ghcr.io/gtk-rs/gtk3-rs/gtk3:latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,29 @@
 on:
   push:
     branches: [master]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/docs.yml"
+      - "atk/**"
+      - "gdk/**"
+      - "gdkwayland/**"
+      - "gdkx11/**"
+      - "gtk/**"
+      - "gtk3-macros/**"
+      - "**/README.md"
   pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/docs.yml"
+      - "atk/**"
+      - "gdk/**"
+      - "gdkwayland/**"
+      - "gdkx11/**"
+      - "gtk/**"
+      - "gtk3-macros/**"
+      - "**/README.md"
   workflow_dispatch:
   release:
     types: [published]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,11 +48,9 @@ jobs:
         with:
           submodules: recursive
           set-safe-directory: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
           components: rustfmt
       - run: git submodule update --checkout
       - run: cargo install rustdoc-stripper
@@ -66,14 +64,12 @@ jobs:
         env:
           RUSTDOCFLAGS: >
             -Zunstable-options --generate-link-to-definition
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: >
-            -p atk -p atk-sys -p gdk -p gdk-sys -p gdkx11 -p gdkx11-sys
-            -p gtk -p gtk3-macros -p gtk-sys -p gdkwayland -p gdkwayland-sys
-            --no-deps
-            --features "atk/v2_34,gdk/v3_24,gdkx11/v3_24,gdkwayland/v3_24,gtk/v3_24_9"
+      - run: >
+          cargo doc
+          -p atk -p atk-sys -p gdk -p gdk-sys -p gdkx11 -p gdkx11-sys
+          -p gtk -p gtk3-macros -p gtk-sys -p gdkwayland -p gdkwayland-sys
+          --no-deps
+          --features "atk/v2_34,gdk/v3_24,gdkx11/v3_24,gdkwayland/v3_24,gtk/v3_24_9"
       - run: echo "RELEASE=$(echo '${{ github.event.release.tag_name }}' | grep -Po '(\d+)\.(\d+)')" >> ${GITHUB_ENV}
       - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" == "release" ]; then echo 'stable/${{ env.RELEASE }}'; else echo 'git'; fi)" >> ${GITHUB_ENV}
       - name: Grab gtk-rs LOGO

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,15 @@
+name: Typos
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+jobs:
+  typos:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v7
+      - name: Check spelling
+        uses: crate-ci/typos@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,7 +1,25 @@
 on:
   push:
     branches: [master]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/windows.yml"
+      - "atk/**"
+      - "examples/**"
+      - "gdk/**"
+      - "gtk/**"
+      - "gtk3-macros/**"
   pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/windows.yml"
+      - "atk/**"
+      - "examples/**"
+      - "gdk/**"
+      - "gtk/**"
+      - "gtk3-macros/**"
   workflow_dispatch:
 
 name: Windows

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -114,27 +114,17 @@ jobs:
 
       - uses: actions/checkout@v7
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          default: true
 
       - name: test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path ${{ matrix.conf.name }}/Cargo.toml ${{ matrix.conf.args }}
+        run: cargo test --manifest-path ${{ matrix.conf.name }}/Cargo.toml ${{ matrix.conf.args }}
         if: matrix.conf.test
 
       - name: test sys
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path ${{ matrix.conf.name }}/sys/Cargo.toml ${{ matrix.conf.args }}
+        run: cargo test --manifest-path ${{ matrix.conf.name }}/sys/Cargo.toml ${{ matrix.conf.args }}
         if: matrix.conf.test-sys
 
       - name: build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path ${{ matrix.conf.name }}/Cargo.toml ${{ matrix.conf.args }}
+        run: cargo build --manifest-path ${{ matrix.conf.name }}/Cargo.toml ${{ matrix.conf.args }}

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,22 @@
+[files]
+extend-exclude = [
+    "auto",
+    "gdk/src/keys.rs",
+    "gdk/sys/src/lib.rs",
+    "gdk/sys/tests/abi.rs",
+    "gdk/sys/tests/constant.c",
+    "gir-files/**",
+    "gir/**",
+    "gtk/sys/src/lib.rs",
+    "**/**/versions.txt",
+]
+
+[default.extend-words]
+# Ignore false-positives
+gir = "gir"
+mak = "mak"
+anid = "anid"
+lamda = "lamda"
+inout = "inout"
+relm = "relm"
+consts = "consts"

--- a/examples/basic_subclass/README.md
+++ b/examples/basic_subclass/README.md
@@ -1,7 +1,7 @@
 # Basic Subclass
 
 This example creates a `GtkApplication` and a `GtkApplicationWindow` subclass
-and showcases how you can override virtual funcitons such as `startup`
+and showcases how you can override virtual functions such as `startup`
 and `activate` and how to interact with the GObjects and their private
 structs.
 

--- a/examples/basic_subclass/simple_application/imp.rs
+++ b/examples/basic_subclass/simple_application/imp.rs
@@ -27,12 +27,12 @@ impl ObjectImpl for SimpleApplication {}
 impl ApplicationImpl for SimpleApplication {
     /// `gio::Application::activate` is what gets called when the
     /// application is launched by the desktop environment and
-    /// aksed to present itself.
+    /// asked to present itself.
     fn activate(&self) {
         let window = self
             .window
             .get()
-            .expect("Should always be initiliazed in gio_application_startup");
+            .expect("Should always be initialized in gio_application_startup");
         window.show_all();
         window.present();
     }

--- a/examples/basic_subclass/simple_window/imp.rs
+++ b/examples/basic_subclass/simple_window/imp.rs
@@ -25,7 +25,7 @@ impl ObjectSubclass for SimpleWindow {
 }
 
 impl ObjectImpl for SimpleWindow {
-    // Here we are overriding the glib::Objcet::contructed
+    // Here we are overriding the glib::Objcet::constructed
     // method. Its what gets called when we create our Object
     // and where we can initialize things.
     fn constructed(&self) {

--- a/examples/list_store/main.rs
+++ b/examples/list_store/main.rs
@@ -173,7 +173,7 @@ fn create_model() -> gtk::ListStore {
             fixed: false,
             number: 6112,
             severity: "Normal".to_string(),
-            description: "netscape-like collapsable toolbars".to_string(),
+            description: "netscape-like collapsible toolbars".to_string(),
         },
         Data {
             fixed: false,

--- a/gtk/src/container.rs
+++ b/gtk/src/container.rs
@@ -73,7 +73,7 @@ pub trait ContainerExtManual: IsA<Container> + sealed::Sealed + 'static {
             if !pspec.flags().contains(glib::ParamFlags::WRITABLE)
                 || !pspec.flags().contains(glib::ParamFlags::READWRITE)
             {
-                panic!("The Container property '{property_name}' is not writeable");
+                panic!("The Container property '{property_name}' is not writable");
             }
 
             assert!(


### PR DESCRIPTION
* Added workflows from gtk4-4s: `auto-update`, `typos`.
* Added dependabot config.
* Added `paths:` filters for workflows so they only run when they need to.  (Except for the container build workflow; I'm going to make the changes required to rebuild the container in a separate PR.)
* Removed usages of the `actions-rs/*` GH actions, as they're unmaintained and archived, and easy replacements exist.