### PR TITLE
Fix docs job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,12 @@ jobs:
     env:
       RELEASES: |
         0.18=0.18
-      RUSTFLAGS: --cfg docsrs
+      RUSTDOCFLAGS: >
+        --extern-html-root-url=wayland_client=https://smithay.github.io/wayland-rs/
+        --extern-html-root-url=x11=https://docs.rs/x11/latest/
+        --cfg docsrs
+        -Zunstable-options --generate-link-to-definition
+      DOCS_RS: 1
     steps:
       - uses: actions/checkout@v7
         with:
@@ -58,9 +63,6 @@ jobs:
           apt-get update
           apt-get install -y python3-requests
       - run: echo "RUSTDOCFLAGS=$(eval python3 ./gir-rustdoc/gir-rustdoc.py --pages-url 'https://gtk-rs.org/gtk3-rs/' --default-branch 'master' pre-docs | xargs)" >> ${GITHUB_ENV}
-        env:
-          RUSTDOCFLAGS: >
-            -Zunstable-options --generate-link-to-definition
       - run: >
           cargo doc
           -p atk -p atk-sys -p gdk -p gdk-sys -p gdkx11 -p gdkx11-sys

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,10 +38,7 @@ jobs:
       image: ghcr.io/gtk-rs/gtk3-rs/gtk3:latest
     env:
       RELEASES: |
-        0.17=0.17
-        0.16=0.16
-        0.15=0.15
-        0.14=0.14
+        0.18=0.18
       RUSTFLAGS: --cfg docsrs
     steps:
       - uses: actions/checkout@v7

--- a/gdk/sys/build.rs
+++ b/gdk/sys/build.rs
@@ -1,15 +1,13 @@
-#[cfg(not(docsrs))]
 use std::io;
-#[cfg(not(docsrs))]
 use std::io::prelude::*;
-#[cfg(not(docsrs))]
 use std::process;
 
-#[cfg(docsrs)]
-fn main() {} // prevent linking libraries to avoid documentation failure
-
-#[cfg(not(docsrs))]
 fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        // prevent linking libraries to avoid documentation failure
+        return;
+    }
+
     if let Err(s) = system_deps::Config::new().probe() {
         let _ = writeln!(io::stderr(), "{s}");
         process::exit(1);
@@ -20,7 +18,6 @@ fn main() {
     check_features();
 }
 
-#[cfg(not(docsrs))]
 fn check_features() {
     const PKG_CONFIG_PACKAGE: &str = "gdk-3.0";
 

--- a/gtk/build.rs
+++ b/gtk/build.rs
@@ -3,18 +3,26 @@ fn main() {
 }
 
 fn check_features() {
-    // The pkg-config file defines a `targets` variable listing the
-    // various backends that gdk (yes, gdk) was compiled for.
-    // We extract that and create gdk_backend="x11" and the like
-    // as configuration variables.
-    // For reference, the backend set at time of writing consists of:
-    // x11 win32 quartz broadway wayland
-    println!(
-        "cargo:rustc-check-cfg=cfg(gdk_backend, values(\"x11\", \"win32\", \"quartz\", \"broadway\", \"wayland\"))"
-    );
-    if let Ok(targets) = pkg_config::get_variable("gtk+-3.0", "targets") {
-        for target in targets.split_whitespace() {
-            println!("cargo:rustc-cfg=gdk_backend=\"{target}\"");
+    const BACKENDS: [&str; 5] = ["x11", "win32", "quartz", "broadway", "wayland"];
+
+    let values = BACKENDS.map(|backend| format!("\"{backend}\"")).join(", ");
+    println!("cargo:rustc-check-cfg=cfg(gdk_backend, values({values}))");
+
+    if std::env::var("DOCS_RS").is_ok() {
+        // There is no GTK to probe when building documentation, so assume every
+        // backend is present rather than documenting none of the gated API.
+        for backend in BACKENDS {
+            println!("cargo:rustc-cfg=gdk_backend=\"{backend}\"");
+        }
+    } else {
+        // The pkg-config file defines a `targets` variable listing the
+        // various backends that gdk (yes, gdk) was compiled for.
+        // We extract that and create gdk_backend="x11" and the like
+        // as configuration variables.
+        if let Ok(targets) = pkg_config::get_variable("gtk+-3.0", "targets") {
+            for target in targets.split_whitespace() {
+                println!("cargo:rustc-cfg=gdk_backend=\"{target}\"");
+            }
         }
     }
 }


### PR DESCRIPTION
This updates `RELEASES` (only 0.18 now) and `RUSTDOCFLAGS`, sets `DOCS_RS`, updates the gdk-sys `build.rs` to use `DOCS_RS`, and "enables" all `gdk_backend`s in gtk's `build.rs` for a docs build so backend-specific stuff will get documented.