### PR TITLE
Docker image updates

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,22 +6,45 @@ on:
       - "master"
     paths:
       - "Dockerfile"
+      - ".github/workflows/image.yml"
   pull_request:
     paths:
       - "Dockerfile"
+      - ".github/workflows/image.yml"
   workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/gtk3
 
 jobs:
   docker:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-          repository: ${{ github.repository }}/gtk3
-          tags: latest
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
 FROM ghcr.io/gtk-rs/gtk-rs-core/core:latest
 
-RUN dnf update -y && \
-    dnf install xorg-x11-server-Xvfb procps-ng \
-    dbus-devel libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-libEGL-devel \
-    libXi-devel libXrandr-devel libXcursor-devel libXdamage-devel libXinerama-devel libXtst-devel -y && \
-    dnf clean all -y
-
-RUN git clone https://gitlab.gnome.org/GNOME/at-spi2-atk.git --depth=1 && \
-    (cd /at-spi2-atk && \
-        meson setup builddir --prefix=/usr --buildtype release -Dtests=false -Datk:introspection=false -Dat-spi2-core:introspection=no && \
-        meson install -C builddir) && \
-    git clone https://gitlab.gnome.org/GNOME/gtk.git --depth=1 -b gtk-3-24 && \
-    (cd /gtk && \
-        meson setup builddir --prefix=/usr --buildtype release -Dintrospection=false -Dexamples=false -Dtests=false -Ddemos=false -Dlibepoxy:tests=false && \
-        meson install -C builddir) && \
-    rm -rf /at-spi2-atk /gtk
+RUN dnf update --assumeyes && \
+    dnf --assumeyes install \
+        atk-devel \
+        gawk \
+        gtk3-devel \
+        procps-ng \
+        python3-requests \
+        wayland-devel \
+        xorg-x11-server-Xvfb && \
+    dnf clean all --assumeyes


### PR DESCRIPTION
Updates the list of RPMs to install and removes the manual ATK installation, as Fedora 44 has a sufficiently-new version.

Updates the image build/pusher workflow to be in-line with what gtk4-rs does.

Closes #858 