### PR TITLE
Use SignalId in the signature for Widget::can_activate_accel()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+## [Unreleased]
+
+### Breaking Changes
+
+- `gtk::Widget::can_activate_accel()` now takes a `SignalId` for the
+  `signal_id` argument instead of `u32`.
+- The closure passed to `gtk::Widget::connect_can_activate_accel()` now
+  takes a `SignalId` for the `signal_id` argument instead of a `u32`.

--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -2701,6 +2701,11 @@ name = "Gtk.Widget"
 status = "generate"
 manual_traits = ["WidgetExtManual"]
     [[object.function]]
+    name = "can_activate_accel"
+    # take SignalId instead of u32
+    manual = true
+    doc_trait_name = "WidgetExtManual"
+    [[object.function]]
     name = "drag_dest_set"
     #array with size
     manual = true
@@ -2804,6 +2809,11 @@ manual_traits = ["WidgetExtManual"]
     [[object.signal]]
     name = "button-release-event"
     inhibit = true
+    [[object.signal]]
+    name = "can-activate-accel"
+    # pass SignalId instead of u32
+    ignore = true
+    doc_trait_name = "WidgetExtManual"
     [[object.signal]]
     name = "delete-event"
     inhibit = true

--- a/gtk/src/auto/widget.rs
+++ b/gtk/src/auto/widget.rs
@@ -103,16 +103,6 @@ pub trait WidgetExt: IsA<Widget> + 'static {
         }
     }
 
-    #[doc(alias = "gtk_widget_can_activate_accel")]
-    fn can_activate_accel(&self, signal_id: u32) -> bool {
-        unsafe {
-            from_glib(ffi::gtk_widget_can_activate_accel(
-                self.as_ref().to_glib_none().0,
-                signal_id,
-            ))
-        }
-    }
-
     #[doc(alias = "gtk_widget_child_focus")]
     fn child_focus(&self, direction: DirectionType) -> bool {
         unsafe {
@@ -2123,37 +2113,6 @@ pub trait WidgetExt: IsA<Widget> + 'static {
                 c"button-release-event".as_ptr(),
                 Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
                     button_release_event_trampoline::<Self, F> as *const (),
-                )),
-                Box_::into_raw(f),
-            )
-        }
-    }
-
-    #[doc(alias = "can-activate-accel")]
-    fn connect_can_activate_accel<F: Fn(&Self, u32) -> bool + 'static>(
-        &self,
-        f: F,
-    ) -> SignalHandlerId {
-        unsafe extern "C" fn can_activate_accel_trampoline<
-            P: IsA<Widget>,
-            F: Fn(&P, u32) -> bool + 'static,
-        >(
-            this: *mut ffi::GtkWidget,
-            signal_id: std::ffi::c_uint,
-            f: glib::ffi::gpointer,
-        ) -> glib::ffi::gboolean {
-            unsafe {
-                let f: &F = &*(f as *const F);
-                f(Widget::from_glib_borrow(this).unsafe_cast_ref(), signal_id).into_glib()
-            }
-        }
-        unsafe {
-            let f: Box_<F> = Box_::new(f);
-            connect_raw(
-                self.as_ptr() as *mut _,
-                c"can-activate-accel".as_ptr(),
-                Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
-                    can_activate_accel_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )

--- a/gtk/src/widget.rs
+++ b/gtk/src/widget.rs
@@ -3,8 +3,10 @@
 use gdk::{DragAction, Event, ModifierType};
 use glib::ffi::gboolean;
 use glib::signal::{SignalHandlerId, connect_raw};
+use glib::subclass::SignalId;
 use glib::translate::*;
 use std::mem::transmute;
+use std::num::NonZeroU32;
 use std::ptr;
 
 use crate::prelude::*;
@@ -32,6 +34,16 @@ mod sealed {
 }
 
 pub trait WidgetExtManual: IsA<Widget> + sealed::Sealed + 'static {
+    #[doc(alias = "gtk_widget_can_activate_accel")]
+    fn can_activate_accel(&self, signal_id: SignalId) -> bool {
+        unsafe {
+            from_glib(ffi::gtk_widget_can_activate_accel(
+                self.as_ref().to_glib_none().0,
+                signal_id.into_glib(),
+            ))
+        }
+    }
+
     #[doc(alias = "gtk_drag_dest_set")]
     fn drag_dest_set(&self, flags: DestDefaults, targets: &[TargetEntry], actions: DragAction) {
         let stashes: Vec<_> = targets.iter().map(|e| e.to_glib_none()).collect();
@@ -85,6 +97,41 @@ pub trait WidgetExtManual: IsA<Widget> + sealed::Sealed + 'static {
                 area.to_glib_none().0,
                 intersection.to_glib_none_mut().0,
             ))
+        }
+    }
+
+    #[doc(alias = "can-activate-accel")]
+    fn connect_can_activate_accel<F: Fn(&Self, SignalId) -> bool + 'static>(
+        &self,
+        f: F,
+    ) -> SignalHandlerId {
+        unsafe extern "C" fn can_activate_accel_trampoline<
+            P: IsA<Widget>,
+            F: Fn(&P, SignalId) -> bool + 'static,
+        >(
+            this: *mut ffi::GtkWidget,
+            signal_id: std::ffi::c_uint,
+            f: glib::ffi::gpointer,
+        ) -> glib::ffi::gboolean {
+            unsafe {
+                if let Some(signal_id) = NonZeroU32::new(signal_id).map(|nz| SignalId::new(nz)) {
+                    let f: &F = &*(f as *const F);
+                    f(Widget::from_glib_borrow(this).unsafe_cast_ref(), signal_id).into_glib()
+                } else {
+                    false.into_glib()
+                }
+            }
+        }
+        unsafe {
+            let f: Box<F> = Box::new(f);
+            connect_raw(
+                self.as_ptr() as *mut _,
+                c"can-activate-accel".as_ptr(),
+                Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
+                    can_activate_accel_trampoline::<Self, F> as *const (),
+                )),
+                Box::into_raw(f),
+            )
         }
     }
 


### PR DESCRIPTION
This also changes the closure taken by Widget::connect_can_activate_accel() to pass a SignalId.

@sdroege @bilelmoussaoui do we have a standard way to note breaking API changes, like a "migrating" document or anything like that?  For now I'm using `CHANGELOG.md` to note things like that (gtk3-rs didn't have one before, so now it does).