### PR TITLE
Fix inconsistency in MessageDialog traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   - `gtk::TreeModelSort`
   - `gtk::TreeStore`
 - New methods and signals:
+  - `gtk::MessageDialog::with_markup()`, a constructor whose message is
+    interpreted as Pango markup
   - `gtk::Clipboard::connect_owner_change()`
   - `gtk::EntryExt::connect_toggle_direction()` and
     `gtk::EntryExt::emit_toggle_direction()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,17 @@
   Code using `gtk::prelude::*` is unaffected, but code that imports
   `WidgetExt` by name, or that calls either method through it, must be
   updated.
+- The hand-written `MessageDialogExt` has been renamed to
+  `MessageDialogExtManual`, and its methods now match the C functions
+  they call: `set_secondary_markup()` is now
+  `format_secondary_markup()`, and `set_secondary_text()` is now
+  `format_secondary_text()`.  It previously shared its name with the
+  generated `MessageDialogExt` while being re-exported as
+  `gtk::MessageDialogExt` instead of through the prelude, so importing
+  it silently replaced the generated trait.  Both are now in the
+  prelude.  Note that `format_secondary_text()` also clears
+  `secondary-use-markup`, which the generated `set_secondary_text()`
+  property setter does not.
 - The opaque class and interface type aliases in `atk-sys`, `gdk-sys`,
   and `gdkx11-sys` are no longer pointers.  For example,
   `GdkFrameClockClass` is now `_GdkFrameClockClass` rather than `*mut

--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -1536,6 +1536,9 @@ status = "generate"
 generate_builder = true
 manual_traits = ["MessageDialogExtManual"]
     [[object.function]]
+    pattern = "new|new_with_markup"
+    manual = true
+    [[object.function]]
     pattern = "format_secondary_(markup|text)"
     manual = true
     [[object.function]]

--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -1534,6 +1534,10 @@ generate_builder = true
 name = "Gtk.MessageDialog"
 status = "generate"
 generate_builder = true
+manual_traits = ["MessageDialogExtManual"]
+    [[object.function]]
+    pattern = "format_secondary_(markup|text)"
+    manual = true
     [[object.function]]
     name = "get_message_area"
         [object.function.return]

--- a/gtk/src/auto/message_dialog.rs
+++ b/gtk/src/auto/message_dialog.rs
@@ -25,29 +25,12 @@ glib::wrapper! {
 impl MessageDialog {
     pub const NONE: Option<&'static MessageDialog> = None;
 
-    //#[doc(alias = "gtk_message_dialog_new")]
-    //pub fn new(parent: Option<&impl IsA<Window>>, flags: DialogFlags, type_: MessageType, buttons: ButtonsType, message_format: Option<&str>, : /*Unknown conversion*//*Unimplemented*/Basic: VarArgs) -> MessageDialog {
-    //    unsafe { TODO: call ffi:gtk_message_dialog_new() }
-    //}
-
-    //#[doc(alias = "gtk_message_dialog_new_with_markup")]
-    //#[doc(alias = "new_with_markup")]
-    //pub fn with_markup(parent: Option<&impl IsA<Window>>, flags: DialogFlags, type_: MessageType, buttons: ButtonsType, message_format: Option<&str>, : /*Unknown conversion*//*Unimplemented*/Basic: VarArgs) -> MessageDialog {
-    //    unsafe { TODO: call ffi:gtk_message_dialog_new_with_markup() }
-    //}
-
     // rustdoc-stripper-ignore-next
     /// Creates a new builder-pattern struct instance to construct [`MessageDialog`] objects.
     ///
     /// This method returns an instance of [`MessageDialogBuilder`](crate::builders::MessageDialogBuilder) which can be used to create [`MessageDialog`] objects.
     pub fn builder() -> MessageDialogBuilder {
         MessageDialogBuilder::new()
-    }
-}
-
-impl Default for MessageDialog {
-    fn default() -> Self {
-        glib::object::Object::new::<Self>()
     }
 }
 

--- a/gtk/src/auto/message_dialog.rs
+++ b/gtk/src/auto/message_dialog.rs
@@ -517,16 +517,6 @@ impl MessageDialogBuilder {
 }
 
 pub trait MessageDialogExt: IsA<MessageDialog> + 'static {
-    //#[doc(alias = "gtk_message_dialog_format_secondary_markup")]
-    //fn format_secondary_markup(&self, message_format: &str, : /*Unknown conversion*//*Unimplemented*/Basic: VarArgs) {
-    //    unsafe { TODO: call ffi:gtk_message_dialog_format_secondary_markup() }
-    //}
-
-    //#[doc(alias = "gtk_message_dialog_format_secondary_text")]
-    //fn format_secondary_text(&self, message_format: Option<&str>, : /*Unknown conversion*//*Unimplemented*/Basic: VarArgs) {
-    //    unsafe { TODO: call ffi:gtk_message_dialog_format_secondary_text() }
-    //}
-
     #[doc(alias = "gtk_message_dialog_get_message_area")]
     #[doc(alias = "get_message_area")]
     #[doc(alias = "message-area")]

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -144,7 +144,6 @@ pub use crate::app_chooser::AppChooser;
 pub use crate::border::Border;
 pub use crate::entry_buffer::EntryBuffer;
 pub use crate::file_filter_info::FileFilterInfo;
-pub use crate::message_dialog::MessageDialogExt;
 pub use crate::page_range::PageRange;
 pub use crate::recent_data::RecentData;
 pub use crate::requisition::Requisition;

--- a/gtk/src/message_dialog.rs
+++ b/gtk/src/message_dialog.rs
@@ -35,6 +35,35 @@ impl MessageDialog {
             .unsafe_cast()
         }
     }
+
+    #[doc(alias = "gtk_message_dialog_new_with_markup")]
+    #[doc(alias = "new_with_markup")]
+    pub fn with_markup<T: IsA<Window>>(
+        parent: Option<&T>,
+        flags: DialogFlags,
+        type_: MessageType,
+        buttons: ButtonsType,
+        message: Option<&str>,
+    ) -> MessageDialog {
+        assert_initialized_main_thread!();
+        unsafe {
+            Widget::from_glib_none(ffi::gtk_message_dialog_new_with_markup(
+                parent.map(|p| p.as_ref()).to_glib_none().0,
+                flags.into_glib(),
+                type_.into_glib(),
+                buttons.into_glib(),
+                message.to_glib_none().0,
+            ))
+            .unsafe_cast()
+        }
+    }
+}
+
+impl Default for MessageDialog {
+    fn default() -> Self {
+        assert_initialized_main_thread!();
+        glib::Object::new()
+    }
 }
 
 pub trait MessageDialogExtManual: IsA<MessageDialog> + 'static {

--- a/gtk/src/message_dialog.rs
+++ b/gtk/src/message_dialog.rs
@@ -37,9 +37,9 @@ impl MessageDialog {
     }
 }
 
-pub trait MessageDialogExt: IsA<MessageDialog> + 'static {
+pub trait MessageDialogExtManual: IsA<MessageDialog> + 'static {
     #[doc(alias = "gtk_message_dialog_format_secondary_markup")]
-    fn set_secondary_markup(&self, message: Option<&str>) {
+    fn format_secondary_markup(&self, message: Option<&str>) {
         match message {
             Some(m) => unsafe {
                 let message: Stash<*const c_char, _> = m.to_glib_none();
@@ -60,7 +60,7 @@ pub trait MessageDialogExt: IsA<MessageDialog> + 'static {
     }
 
     #[doc(alias = "gtk_message_dialog_format_secondary_text")]
-    fn set_secondary_text(&self, message: Option<&str>) {
+    fn format_secondary_text(&self, message: Option<&str>) {
         match message {
             Some(m) => unsafe {
                 let message: Stash<*const c_char, _> = m.to_glib_none();
@@ -81,4 +81,4 @@ pub trait MessageDialogExt: IsA<MessageDialog> + 'static {
     }
 }
 
-impl<O: IsA<MessageDialog>> MessageDialogExt for O {}
+impl<O: IsA<MessageDialog>> MessageDialogExtManual for O {}

--- a/gtk/src/prelude.rs
+++ b/gtk/src/prelude.rs
@@ -33,6 +33,7 @@ pub use crate::invisible::InvisibleExtManual;
 pub use crate::list_box::ListBoxExtManual;
 pub use crate::list_store::GtkListStoreExtManual;
 pub use crate::menu::GtkMenuExtManual;
+pub use crate::message_dialog::MessageDialogExtManual;
 pub use crate::native_dialog::NativeDialogExtManual;
 pub use crate::notebook::NotebookExtManual;
 pub use crate::stack_switcher::StackSwitcherExtManual;


### PR DESCRIPTION
The manual trait was named `MessageDialogExt`, which collides with the auto-generated trait name, so I've renamed it to
`MessageDialogExtManual`.

There were also duplicate methods on the two traits, so I've used gtk4-rs's pattern here and have named the manual methods with `format_` prefixes.

This also adds a `MessageDialog::with_markup()` constructor that was missing.