### PR TITLE
Generate more builders for gtk types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
   - `accessible_id()` and `accessible_help_text()` on the builders for
     `gtk::HeaderBarAccessible`, `gtk::PlugAccessible`, and
     `gtk::SocketAccessible`
+- Builders are now generated for `gtk::EventControllerKey`,
+  `gtk::EventControllerMotion`, `gtk::EventControllerScroll`,
+  `gtk::FileChooserWidgetAccessible`, `gtk::GestureStylus`,
+  `gtk::Settings`, and `gtk::ShortcutLabel`.
 - New feature flags:
   - `atk`'s `v2_52` adds `atk::AtkObjectExt::help_text()`,
     `set_help_text()`, `connect_attribute_changed()`, and

--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -10,6 +10,7 @@ target_path = "."
 work_mode = "normal"
 generate_safety_asserts = true
 deprecate_by_min_version = true
+generate_builder = true
 single_version_file = true
 
 generate = [
@@ -26,7 +27,6 @@ generate = [
     "Gtk.ButtonRole",
     "Gtk.ButtonsType",
     "Gtk.CalendarDisplayOptions",
-    "Gtk.CellAreaContext",
     "Gtk.CellLayout",
     "Gtk.CellRendererAccelMode",
     "Gtk.CellRendererMode",
@@ -49,7 +49,6 @@ generate = [
     "Gtk.FileChooserError",
     "Gtk.FileFilter",
     "Gtk.FileFilterFlags",
-    "Gtk.GestureSingle",
     "Gtk.IconInfo",
     "Gtk.IconLookupFlags",
     "Gtk.IconSize",
@@ -351,7 +350,6 @@ status = "generate"
 [[object]]
 name = "Gtk.AboutDialog"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "set_website_label"
         [[object.function.parameter]]
@@ -385,7 +383,6 @@ manual_traits = ["AccelGroupExtManual"]
 [[object]]
 name = "Gtk.AccelLabel"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Actionable"
@@ -398,7 +395,6 @@ status = "generate"
 [[object]]
 name = "Gtk.ActionBar"
 status = "generate"
-generate_builder = true
     [[object.child_prop]]
     name = "pack-type"
     type = "Gtk.PackType"
@@ -409,17 +405,14 @@ generate_builder = true
 [[object]]
 name = "Gtk.Adjustment"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.AppChooserButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.AppChooserDialog"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "get_widget"
         [object.function.return]
@@ -428,12 +421,10 @@ generate_builder = true
 [[object]]
 name = "Gtk.AppChooserWidget"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Application"
 status = "generate"
-generate_builder = true
 builder_postprocess = "Application::register_startup_hook(&ret);"
 trait_name = "GtkApplicationExt"
 manual_traits = ["gio::ApplicationExtManual"]
@@ -444,7 +435,6 @@ manual_traits = ["gio::ApplicationExtManual"]
 [[object]]
 name = "Gtk.ApplicationWindow"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "new"
     ignore = true
@@ -452,12 +442,10 @@ generate_builder = true
 [[object]]
 name = "Gtk.AspectFrame"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Assistant"
 status = "generate"
-generate_builder = true
     [[object.child_prop]]
     name = "complete"
     type = "gboolean"
@@ -480,7 +468,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.Box"
 status = "generate"
-generate_builder = true
     [[object.child_prop]]
     name = "expand"
     type = "gboolean"
@@ -515,6 +502,7 @@ manual_traits = ["BuildableExtManual"]
 [[object]]
 name = "Gtk.Builder"
 status = "generate"
+generate_builder = false # constructed by GTK, not directly
 manual_traits = ["BuilderExtManual"]
     [[object.function]]
     pattern = ".+_from_file"
@@ -549,12 +537,10 @@ manual_traits = ["BuilderExtManual"]
 [[object]]
 name = "Gtk.Button"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ButtonBox"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "get_child_non_homogeneous"
     rename = "child_is_non_homogeneous"
@@ -565,7 +551,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.Calendar"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "get_day_is_marked"
     rename = "day_is_marked"
@@ -613,7 +598,11 @@ status = "generate"
 [[object]]
 name = "Gtk.CellAreaBox"
 status = "generate"
-generate_builder = true
+
+[[object]]
+name = "Gtk.CellAreaContext"
+status = "generate"
+generate_builder = false # constructed by GTK, not directly
 
 [[object]]
 name = "Gtk.CellEditable"
@@ -627,7 +616,6 @@ status = "generate"
 [[object]]
 name = "Gtk.CellRenderer"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "render"
         [[object.function.parameter]]
@@ -653,7 +641,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.CellRendererAccel"
 status = "generate"
-generate_builder = true
     [[object.signal]]
     name = "accel-cleared"
         [[object.signal.parameter]]
@@ -670,7 +657,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.CellRendererCombo"
 status = "generate"
-generate_builder = true
     [[object.signal]]
     name = "changed"
         [[object.signal.parameter]]
@@ -684,7 +670,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.CellRendererPixbuf"
 status = "generate"
-generate_builder = true
 manual_traits = ["CellRendererPixbufExtManual"]
     [[object.property]]
     name = "surface"
@@ -697,22 +682,18 @@ manual_traits = ["CellRendererPixbufExtManual"]
 [[object]]
 name = "Gtk.CellRendererProgress"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.CellRendererSpin"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.CellRendererSpinner"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.CellRendererText"
 status = "generate"
-generate_builder = true
     [[object.signal]]
     name = "edited"
         [[object.signal.parameter]]
@@ -722,7 +703,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.CellRendererToggle"
 status = "generate"
-generate_builder = true
     [[object.signal]]
     name = "toggled"
         [[object.signal.parameter]]
@@ -732,7 +712,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.CellView"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "set_displayed_row"
     [[object.function.parameter]]
@@ -742,12 +721,10 @@ generate_builder = true
 [[object]]
 name = "Gtk.CheckButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.CheckMenuItem"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Clipboard"
@@ -791,7 +768,6 @@ status = "generate"
 [[object]]
 name = "Gtk.ColorButton"
 status = "generate"
-generate_builder = true
 manual_traits = ["ColorButtonExtManual"]
     [[object.function]]
     name = "new_with_color"
@@ -819,17 +795,14 @@ manual_traits = ["ColorChooserExtManual"]
 [[object]]
 name = "Gtk.ColorChooserDialog"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ColorChooserWidget"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ComboBox"
 status = "generate"
-generate_builder = true
 manual_traits = ["ComboBoxExtManual"]
     [[object.function]]
     name = "set_active_iter"
@@ -852,7 +825,6 @@ manual_traits = ["ComboBoxExtManual"]
 [[object]]
 name = "Gtk.ComboBoxText"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Container"
@@ -871,7 +843,6 @@ manual_traits = ["ContainerExtManual"]
 [[object]]
 name = "Gtk.Dialog"
 status = "generate"
-generate_builder = true
 manual_traits = ["DialogExtManual"]
     [[object.function]]
     name = "add_buttons"
@@ -900,7 +871,6 @@ manual_traits = ["DialogExtManual"]
 [[object]]
 name = "Gtk.DrawingArea"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Editable"
@@ -914,7 +884,6 @@ manual_traits = ["EditableSignals"]
 [[object]]
 name = "Gtk.Entry"
 status = "generate"
-generate_builder = true
 manual_traits = ["EntryExtManual"]
     [[object.function]]
     name = "get_buffer"
@@ -958,12 +927,10 @@ manual_traits = ["EntryExtManual"]
 [[object]]
 name = "Gtk.EntryBuffer"
 status = "manual"
-generate_builder = true
 
 [[object]]
 name = "Gtk.EntryCompletion"
 status = "generate"
-generate_builder = true
 manual_traits = ["EntryCompletionExtManual"]
     [[object.signal]]
     name = "insert-prefix"
@@ -982,7 +949,6 @@ manual_traits = ["EntryCompletionExtManual"]
 [[object]]
 name = "Gtk.EventBox"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.EventControllerKey"
@@ -1007,7 +973,6 @@ version = "3.24"
 [[object]]
 name = "Gtk.Expander"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "new"
         [[object.function.parameter]]
@@ -1030,22 +995,18 @@ manual_traits = ["FileChooserExtManual"]
 [[object]]
 name = "Gtk.FileChooserButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.FileChooserDialog"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.FileChooserNative"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.FileChooserWidget"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.FileChooserWidgetAccessible"
@@ -1054,13 +1015,11 @@ status = "generate"
 [[object]]
 name = "Gtk.Fixed"
 status = "generate"
-generate_builder = true
 manual_traits = ["FixedExtManual"]
 
 [[object]]
 name = "Gtk.FlowBox"
 status = "generate"
-generate_builder = true
 manual_traits = ["FlowBoxExtManual"]
     [[object.function]]
     name = "bind_model"
@@ -1072,12 +1031,10 @@ manual_traits = ["FlowBoxExtManual"]
 [[object]]
 name = "Gtk.FlowBoxChild"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.FontButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.FontChooser"
@@ -1095,7 +1052,6 @@ status = "generate"
 [[object]]
 name = "Gtk.FontChooserDialog"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.FontChooserLevel"
@@ -1105,12 +1061,10 @@ version = "3.24"
 [[object]]
 name = "Gtk.FontChooserWidget"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Frame"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Gesture"
@@ -1154,27 +1108,27 @@ status = "generate"
 [[object]]
 name = "Gtk.GestureDrag"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.GestureLongPress"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.GestureMultiPress"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.GesturePan"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.GestureRotate"
 status = "generate"
-generate_builder = true
+
+[[object]]
+name = "Gtk.GestureSingle"
+status = "generate"
+generate_builder = false # constructed by GTK, not directly
 
 [[object]]
 name = "Gtk.GestureStylus"
@@ -1188,17 +1142,14 @@ manual_traits = ["GestureStylusExtManual"]
 [[object]]
 name = "Gtk.GestureSwipe"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.GestureZoom"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.GLArea"
 status = "generate"
-generate_builder = true
 module_name = "gl_area"
     [[object.signal]]
     pattern = "render"
@@ -1211,7 +1162,6 @@ module_name = "gl_area"
 [[object]]
 name = "Gtk.Grid"
 status = "generate"
-generate_builder = true
 child_name = "cell"
     [[object.child_prop]]
     name = "height"
@@ -1229,7 +1179,6 @@ child_name = "cell"
 [[object]]
 name = "Gtk.HeaderBar"
 status = "generate"
-generate_builder = true
     [[object.child_prop]]
     name = "pack-type"
     type = "Gtk.PackType"
@@ -1240,7 +1189,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.HeaderBarAccessible"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.IconTheme"
@@ -1266,7 +1214,6 @@ status = "generate"
 [[object]]
 name = "Gtk.IconView"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "enable_model_drag_dest"
     #array with size
@@ -1328,7 +1275,6 @@ status = "generate"
 [[object]]
 name = "Gtk.IMContextSimple"
 status = "generate"
-generate_builder = true
 manual_traits = ["IMContextSimpleExtManual"]
     [[object.function]]
     name = "add_compose_file"
@@ -1341,12 +1287,10 @@ manual_traits = ["IMContextSimpleExtManual"]
 [[object]]
 name = "Gtk.IMMulticontext"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.InfoBar"
 status = "generate"
-generate_builder = true
     [[object.property]]
     name = "revealed"
     [[object.function]]
@@ -1359,7 +1303,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.Invisible"
 status = "generate"
-generate_builder = true
 manual_traits = ["InvisibleExtManual"]
     [[object.function]]
     name = "get_screen"
@@ -1369,7 +1312,6 @@ manual_traits = ["InvisibleExtManual"]
 [[object]]
 name = "Gtk.Label"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "new_with_mnemonic"
         [[object.function.parameter]]
@@ -1390,7 +1332,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.Layout"
 status = "generate"
-generate_builder = true
     [[object.child_prop]]
     name = "x"
     type = "gint"
@@ -1401,12 +1342,10 @@ generate_builder = true
 [[object]]
 name = "Gtk.LevelBar"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.LinkButton"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "new_with_label"
         [[object.function.parameter]]
@@ -1419,7 +1358,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.ListBox"
 status = "generate"
-generate_builder = true
 manual_traits = ["ListBoxExtManual"]
     [[object.function]]
     name = "bind_model"
@@ -1431,7 +1369,6 @@ manual_traits = ["ListBoxExtManual"]
 [[object]]
 name = "Gtk.ListBoxRow"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ListStore"
@@ -1473,12 +1410,10 @@ manual_traits = ["GtkListStoreExtManual"]
 [[object]]
 name = "Gtk.LockButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Menu"
 status = "generate"
-generate_builder = true
 child_type = "Gtk.MenuItem"
 child_name = "item"
 trait_name = "GtkMenuExt"
@@ -1502,17 +1437,14 @@ manual_traits = ["GtkMenuExtManual"]
 [[object]]
 name = "Gtk.MenuBar"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.MenuButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.MenuItem"
 status = "generate"
-generate_builder = true
 trait_name = "GtkMenuItemExt"
     [[object.function]]
     name = "activate"
@@ -1528,12 +1460,10 @@ status = "generate"
 [[object]]
 name = "Gtk.MenuToolButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.MessageDialog"
 status = "generate"
-generate_builder = true
 manual_traits = ["MessageDialogExtManual"]
     [[object.function]]
     pattern = "new|new_with_markup"
@@ -1549,13 +1479,11 @@ manual_traits = ["MessageDialogExtManual"]
 [[object]]
 name = "Gtk.ModelButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.MountOperation"
 status = "generate"
 trait_name = "GtkMountOperationExt"
-generate_builder = true
 
 [[object]]
 name = "Gtk.NativeDialog"
@@ -1569,7 +1497,6 @@ manual_traits = ["NativeDialogExtManual"]
 [[object]]
 name = "Gtk.Notebook"
 status = "generate"
-generate_builder = true
 manual_traits = ["NotebookExtManual"]
     # The following functions need integer type adjustments
     [[object.function]]
@@ -1657,12 +1584,10 @@ manual_traits = ["NotebookExtManual"]
 [[object]]
 name = "Gtk.OffscreenWindow"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Overlay"
 status = "generate"
-generate_builder = true
 manual_traits = ["OverlaySignals"]
     [[object.child_prop]]
     name = "index"
@@ -1671,7 +1596,6 @@ manual_traits = ["OverlaySignals"]
 [[object]]
 name = "Gtk.PadController"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "set_action_entries"
     manual = true
@@ -1697,7 +1621,6 @@ status = "generate"
 [[object]]
 name = "Gtk.Paned"
 status = "generate"
-generate_builder = true
     [[object.child_prop]]
     name = "resize"
     type = "gboolean"
@@ -1725,7 +1648,6 @@ status = "generate"
 [[object]]
 name = "Gtk.PlacesSidebar"
 status = "generate"
-generate_builder = true
     [[object.signal]]
     name = "drag-action-requested"
     #[gio::File]
@@ -1738,24 +1660,20 @@ generate_builder = true
 [[object]]
 name = "Gtk.Plug"
 status = "generate"
-generate_builder = true
 cfg_condition = "gdk_backend = \"x11\""
 
 [[object]]
 name = "Gtk.PlugAccessible"
 status = "generate"
-generate_builder = true
 cfg_condition = "gdk_backend = \"x11\""
 
 [[object]]
 name = "Gtk.Popover"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.PopoverMenu"
 status = "generate"
-generate_builder = true
     [[object.child_prop]]
     name = "position"
     type = "gint"
@@ -1776,7 +1694,6 @@ status = "generate"
 [[object]]
 name = "Gtk.PrintOperation"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "get_error"
     # It quacks like a fallible function, but it isn't.
@@ -1805,12 +1722,10 @@ status = "generate"
 [[object]]
 name = "Gtk.ProgressBar"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.RadioButton"
 status = "generate"
-generate_builder = true
     [[object.function]]
     pattern = ".+_from_widget"
         [[object.function.parameter]]
@@ -1835,7 +1750,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.RadioMenuItem"
 status = "generate"
-generate_builder = true
     [[object.function]]
     pattern = ".+_from_widget"
         [[object.function.parameter]]
@@ -1860,7 +1774,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.RadioToolButton"
 status = "generate"
-generate_builder = true
     [[object.function]]
     pattern = ".+_from_widget"
         [[object.function.parameter]]
@@ -1893,17 +1806,14 @@ status = "generate"
 [[object]]
 name = "Gtk.RecentChooserDialog"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.RecentChooserMenu"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.RecentChooserWidget"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.RecentFilter"
@@ -1915,22 +1825,18 @@ status = "generate"
 [[object]]
 name = "Gtk.RecentManager"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Revealer"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Scale"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ScaleButton"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "get_adjustment"
         [object.function.return]
@@ -1939,12 +1845,10 @@ generate_builder = true
 [[object]]
 name = "Gtk.Scrollbar"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ScrolledWindow"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "get_hadjustment"
         [object.function.return]
@@ -1957,7 +1861,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.SearchBar"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "handle_event"
         [[object.function.parameter]]
@@ -1967,7 +1870,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.SearchEntry"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "handle_event"
         [[object.function.parameter]]
@@ -2020,17 +1922,14 @@ status = "generate"
 [[object]]
 name = "Gtk.Separator"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.SeparatorMenuItem"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.SeparatorToolItem"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Settings"
@@ -2047,45 +1946,37 @@ trait_name = "GtkSettingsExt"
 [[object]]
 name = "Gtk.ShortcutsGroup"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ShortcutsSection"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ShortcutsShortcut"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ShortcutsWindow"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.SizeGroup"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Socket"
 status = "generate"
-generate_builder = true
 cfg_condition = "gdk_backend = \"x11\""
 trait_name = "GtkSocketExt"
 
 [[object]]
 name = "Gtk.SocketAccessible"
 status = "generate"
-generate_builder = true
 cfg_condition = "gdk_backend = \"x11\""
 
 [[object]]
 name = "Gtk.SpinButton"
 status = "generate"
-generate_builder = true
 manual_traits = ["SpinButtonSignals"]
     [[object.function]]
     name = "get_adjustment"
@@ -2098,12 +1989,10 @@ manual_traits = ["SpinButtonSignals"]
 [[object]]
 name = "Gtk.Spinner"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Stack"
 status = "generate"
-generate_builder = true
     [[object.child_prop]]
     name = "icon-name"
     type = "utf8"
@@ -2126,7 +2015,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.StackSidebar"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.StackSwitcher"
@@ -2140,12 +2028,10 @@ manual_traits = ["StackSwitcherExtManual"]
 [[object]]
 name = "Gtk.Statusbar"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.StyleContext"
 status = "generate"
-generate_builder = true
 manual_traits = ["StyleContextExtManual"]
     [[object.function]]
     name = "get_property"
@@ -2157,7 +2043,6 @@ manual_traits = ["StyleContextExtManual"]
 [[object]]
 name = "Gtk.Switch"
 status = "generate"
-generate_builder = true
 manual_traits = ["SwitchExtManual"]
     [[object.signal]]
     name = "state-set"
@@ -2178,7 +2063,6 @@ status = "generate"
 [[object]]
 name = "Gtk.TextBuffer"
 status = "generate"
-generate_builder = true
 manual_traits = ["TextBufferExtManual"]
     [[object.function]]
     name = "get_insert"
@@ -2259,12 +2143,10 @@ boxed_inline = true
 [[object]]
 name = "Gtk.TextMark"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.TextTag"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "event"
         [[object.function.parameter]]
@@ -2277,7 +2159,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.TextView"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "get_default_attributes"
         [object.function.return]
@@ -2299,17 +2180,14 @@ generate_builder = true
 [[object]]
 name = "Gtk.ToggleButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ToggleToolButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Toolbar"
 status = "generate"
-generate_builder = true
 child_name = "item"
     [[object.signal]]
     name = "popup-context-menu"
@@ -2324,12 +2202,10 @@ child_name = "item"
 [[object]]
 name = "Gtk.ToolButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.ToolItem"
 status = "generate"
-generate_builder = true
     [[object.signal]]
     name = "create-menu-proxy"
     inhibit = true
@@ -2337,7 +2213,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.ToolItemGroup"
 status = "generate"
-generate_builder = true
 child_type = "Gtk.ToolItem"
 child_name = "item"
     [[object.child_prop]]
@@ -2356,7 +2231,6 @@ child_name = "item"
 [[object]]
 name = "Gtk.ToolPalette"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.TreeIter"
@@ -2412,6 +2286,7 @@ status = "generate"
 [[object]]
 name = "Gtk.TreeModelFilter"
 status = "generate"
+generate_builder = false # constructed by GTK, not directly
     [[object.function]]
     name = "convert_child_path_to_path"
         [[object.function.parameter]]
@@ -2440,6 +2315,7 @@ status = "generate"
 [[object]]
 name = "Gtk.TreeModelSort"
 status = "generate"
+generate_builder = false # constructed by GTK, not directly
     [[object.function]]
     name = "convert_child_path_to_path"
         [[object.function.parameter]]
@@ -2556,6 +2432,7 @@ status = "generate"
 [[object]]
 name = "Gtk.TreeSelection"
 status = "generate"
+generate_builder = false # constructed by GTK, not directly
     [[object.function]]
     pattern = ".+"
         [[object.function.parameter]]
@@ -2646,7 +2523,6 @@ manual_traits = ["TreeStoreExtManual"]
 [[object]]
 name = "Gtk.TreeView"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "enable_model_drag_dest"
     #array with size
@@ -2682,7 +2558,6 @@ generate_builder = true
 [[object]]
 name = "Gtk.TreeViewColumn"
 status = "generate"
-generate_builder = true
     [[object.function]]
     name = "cell_set_cell_data"
         [[object.function.parameter]]
@@ -2696,12 +2571,10 @@ generate_builder = true
 [[object]]
 name = "Gtk.Viewport"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.VolumeButton"
 status = "generate"
-generate_builder = true
 
 [[object]]
 name = "Gtk.Widget"
@@ -2963,7 +2836,6 @@ manual_traits = ["WidgetExtManual"]
 [[object]]
 name = "Gtk.Window"
 status = "generate"
-generate_builder = true
 trait_name = "GtkWindowExt"
 manual_traits = ["GtkWindowExtManual"]
     [[object.function]]

--- a/gtk/src/auto/event_controller_key.rs
+++ b/gtk/src/auto/event_controller_key.rs
@@ -2,7 +2,7 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
-use crate::{EventController, IMContext, Widget, ffi};
+use crate::{EventController, IMContext, PropagationPhase, Widget, ffi};
 use glib::{
     object::ObjectType as _,
     prelude::*,
@@ -30,6 +30,14 @@ impl EventControllerKey {
             ))
             .unsafe_cast()
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Creates a new builder-pattern struct instance to construct [`EventControllerKey`] objects.
+    ///
+    /// This method returns an instance of [`EventControllerKeyBuilder`](crate::builders::EventControllerKeyBuilder) which can be used to create [`EventControllerKey`] objects.
+    pub fn builder() -> EventControllerKeyBuilder {
+        EventControllerKeyBuilder::new()
     }
 
     #[doc(alias = "gtk_event_controller_key_forward")]
@@ -236,5 +244,50 @@ impl EventControllerKey {
                 Box_::into_raw(f),
             )
         }
+    }
+}
+
+impl Default for EventControllerKey {
+    fn default() -> Self {
+        glib::object::Object::new::<Self>()
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// A [builder-pattern] type to construct [`EventControllerKey`] objects.
+///
+/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
+#[must_use = "The builder must be built to be used"]
+pub struct EventControllerKeyBuilder {
+    builder: glib::object::ObjectBuilder<'static, EventControllerKey>,
+}
+
+impl EventControllerKeyBuilder {
+    fn new() -> Self {
+        Self {
+            builder: glib::object::Object::builder(),
+        }
+    }
+
+    pub fn propagation_phase(self, propagation_phase: PropagationPhase) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("propagation-phase", propagation_phase),
+        }
+    }
+
+    pub fn widget(self, widget: &impl IsA<Widget>) -> Self {
+        Self {
+            builder: self.builder.property("widget", widget.clone().upcast()),
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the [`EventControllerKey`].
+    #[must_use = "Building the object from the builder is usually expensive and is not expected to have side effects"]
+    pub fn build(self) -> EventControllerKey {
+        assert_initialized_main_thread!();
+        self.builder.build()
     }
 }

--- a/gtk/src/auto/event_controller_motion.rs
+++ b/gtk/src/auto/event_controller_motion.rs
@@ -2,7 +2,7 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
-use crate::{EventController, Widget, ffi};
+use crate::{EventController, PropagationPhase, Widget, ffi};
 use glib::{
     object::ObjectType as _,
     prelude::*,
@@ -30,6 +30,14 @@ impl EventControllerMotion {
             ))
             .unsafe_cast()
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Creates a new builder-pattern struct instance to construct [`EventControllerMotion`] objects.
+    ///
+    /// This method returns an instance of [`EventControllerMotionBuilder`](crate::builders::EventControllerMotionBuilder) which can be used to create [`EventControllerMotion`] objects.
+    pub fn builder() -> EventControllerMotionBuilder {
+        EventControllerMotionBuilder::new()
     }
 
     #[doc(alias = "enter")]
@@ -108,5 +116,52 @@ impl EventControllerMotion {
                 Box_::into_raw(f),
             )
         }
+    }
+}
+
+#[cfg(feature = "v3_24")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+impl Default for EventControllerMotion {
+    fn default() -> Self {
+        glib::object::Object::new::<Self>()
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// A [builder-pattern] type to construct [`EventControllerMotion`] objects.
+///
+/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
+#[must_use = "The builder must be built to be used"]
+pub struct EventControllerMotionBuilder {
+    builder: glib::object::ObjectBuilder<'static, EventControllerMotion>,
+}
+
+impl EventControllerMotionBuilder {
+    fn new() -> Self {
+        Self {
+            builder: glib::object::Object::builder(),
+        }
+    }
+
+    pub fn propagation_phase(self, propagation_phase: PropagationPhase) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("propagation-phase", propagation_phase),
+        }
+    }
+
+    pub fn widget(self, widget: &impl IsA<Widget>) -> Self {
+        Self {
+            builder: self.builder.property("widget", widget.clone().upcast()),
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the [`EventControllerMotion`].
+    #[must_use = "Building the object from the builder is usually expensive and is not expected to have side effects"]
+    pub fn build(self) -> EventControllerMotion {
+        assert_initialized_main_thread!();
+        self.builder.build()
     }
 }

--- a/gtk/src/auto/event_controller_scroll.rs
+++ b/gtk/src/auto/event_controller_scroll.rs
@@ -2,7 +2,7 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
-use crate::{EventController, EventControllerScrollFlags, Widget, ffi};
+use crate::{EventController, EventControllerScrollFlags, PropagationPhase, Widget, ffi};
 use glib::{
     object::ObjectType as _,
     prelude::*,
@@ -34,6 +34,14 @@ impl EventControllerScroll {
             ))
             .unsafe_cast()
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Creates a new builder-pattern struct instance to construct [`EventControllerScroll`] objects.
+    ///
+    /// This method returns an instance of [`EventControllerScrollBuilder`](crate::builders::EventControllerScrollBuilder) which can be used to create [`EventControllerScroll`] objects.
+    pub fn builder() -> EventControllerScrollBuilder {
+        EventControllerScrollBuilder::new()
     }
 
     #[doc(alias = "gtk_event_controller_scroll_get_flags")]
@@ -183,5 +191,60 @@ impl EventControllerScroll {
                 Box_::into_raw(f),
             )
         }
+    }
+}
+
+#[cfg(feature = "v3_24")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+impl Default for EventControllerScroll {
+    fn default() -> Self {
+        glib::object::Object::new::<Self>()
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// A [builder-pattern] type to construct [`EventControllerScroll`] objects.
+///
+/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
+#[must_use = "The builder must be built to be used"]
+pub struct EventControllerScrollBuilder {
+    builder: glib::object::ObjectBuilder<'static, EventControllerScroll>,
+}
+
+impl EventControllerScrollBuilder {
+    fn new() -> Self {
+        Self {
+            builder: glib::object::Object::builder(),
+        }
+    }
+
+    #[cfg(feature = "v3_24")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+    pub fn flags(self, flags: EventControllerScrollFlags) -> Self {
+        Self {
+            builder: self.builder.property("flags", flags),
+        }
+    }
+
+    pub fn propagation_phase(self, propagation_phase: PropagationPhase) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("propagation-phase", propagation_phase),
+        }
+    }
+
+    pub fn widget(self, widget: &impl IsA<Widget>) -> Self {
+        Self {
+            builder: self.builder.property("widget", widget.clone().upcast()),
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the [`EventControllerScroll`].
+    #[must_use = "Building the object from the builder is usually expensive and is not expected to have side effects"]
+    pub fn build(self) -> EventControllerScroll {
+        assert_initialized_main_thread!();
+        self.builder.build()
     }
 }

--- a/gtk/src/auto/file_chooser_widget_accessible.rs
+++ b/gtk/src/auto/file_chooser_widget_accessible.rs
@@ -3,6 +3,7 @@
 // DO NOT EDIT
 
 use crate::ffi;
+use glib::prelude::*;
 
 glib::wrapper! {
     #[doc(alias = "GtkFileChooserWidgetAccessible")]
@@ -15,4 +16,170 @@ glib::wrapper! {
 
 impl FileChooserWidgetAccessible {
     pub const NONE: Option<&'static FileChooserWidgetAccessible> = None;
+
+    // rustdoc-stripper-ignore-next
+    /// Creates a new builder-pattern struct instance to construct [`FileChooserWidgetAccessible`] objects.
+    ///
+    /// This method returns an instance of [`FileChooserWidgetAccessibleBuilder`](crate::builders::FileChooserWidgetAccessibleBuilder) which can be used to create [`FileChooserWidgetAccessible`] objects.
+    pub fn builder() -> FileChooserWidgetAccessibleBuilder {
+        FileChooserWidgetAccessibleBuilder::new()
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// A [builder-pattern] type to construct [`FileChooserWidgetAccessible`] objects.
+///
+/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
+#[must_use = "The builder must be built to be used"]
+pub struct FileChooserWidgetAccessibleBuilder {
+    builder: glib::object::ObjectBuilder<'static, FileChooserWidgetAccessible>,
+}
+
+impl FileChooserWidgetAccessibleBuilder {
+    fn new() -> Self {
+        Self {
+            builder: glib::object::Object::builder(),
+        }
+    }
+
+    pub fn accessible_description(self, accessible_description: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("accessible-description", accessible_description.into()),
+        }
+    }
+
+    pub fn accessible_help_text(self, accessible_help_text: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("accessible-help-text", accessible_help_text.into()),
+        }
+    }
+
+    pub fn accessible_id(self, accessible_id: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("accessible-id", accessible_id.into()),
+        }
+    }
+
+    pub fn accessible_name(self, accessible_name: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("accessible-name", accessible_name.into()),
+        }
+    }
+
+    pub fn accessible_parent(self, accessible_parent: &impl IsA<atk::Object>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("accessible-parent", accessible_parent.clone().upcast()),
+        }
+    }
+
+    pub fn accessible_role(self, accessible_role: atk::Role) -> Self {
+        Self {
+            builder: self.builder.property("accessible-role", accessible_role),
+        }
+    }
+
+    pub fn accessible_table_caption(
+        self,
+        accessible_table_caption: impl Into<glib::GString>,
+    ) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("accessible-table-caption", accessible_table_caption.into()),
+        }
+    }
+
+    pub fn accessible_table_caption_object(
+        self,
+        accessible_table_caption_object: &impl IsA<atk::Object>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "accessible-table-caption-object",
+                accessible_table_caption_object.clone().upcast(),
+            ),
+        }
+    }
+
+    pub fn accessible_table_column_description(
+        self,
+        accessible_table_column_description: impl Into<glib::GString>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "accessible-table-column-description",
+                accessible_table_column_description.into(),
+            ),
+        }
+    }
+
+    pub fn accessible_table_column_header(
+        self,
+        accessible_table_column_header: &impl IsA<atk::Object>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "accessible-table-column-header",
+                accessible_table_column_header.clone().upcast(),
+            ),
+        }
+    }
+
+    pub fn accessible_table_row_description(
+        self,
+        accessible_table_row_description: impl Into<glib::GString>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "accessible-table-row-description",
+                accessible_table_row_description.into(),
+            ),
+        }
+    }
+
+    pub fn accessible_table_row_header(
+        self,
+        accessible_table_row_header: &impl IsA<atk::Object>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "accessible-table-row-header",
+                accessible_table_row_header.clone().upcast(),
+            ),
+        }
+    }
+
+    pub fn accessible_table_summary(
+        self,
+        accessible_table_summary: &impl IsA<atk::Object>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "accessible-table-summary",
+                accessible_table_summary.clone().upcast(),
+            ),
+        }
+    }
+
+    pub fn accessible_value(self, accessible_value: f64) -> Self {
+        Self {
+            builder: self.builder.property("accessible-value", accessible_value),
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the [`FileChooserWidgetAccessible`].
+    #[must_use = "Building the object from the builder is usually expensive and is not expected to have side effects"]
+    pub fn build(self) -> FileChooserWidgetAccessible {
+        assert_initialized_main_thread!();
+        self.builder.build()
+    }
 }

--- a/gtk/src/auto/gesture_stylus.rs
+++ b/gtk/src/auto/gesture_stylus.rs
@@ -2,7 +2,7 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
-use crate::{EventController, Gesture, GestureSingle, Widget, ffi};
+use crate::{EventController, Gesture, GestureSingle, PropagationPhase, Widget, ffi};
 use glib::{
     object::ObjectType as _,
     prelude::*,
@@ -30,6 +30,14 @@ impl GestureStylus {
             ))
             .unsafe_cast()
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Creates a new builder-pattern struct instance to construct [`GestureStylus`] objects.
+    ///
+    /// This method returns an instance of [`GestureStylusBuilder`](crate::builders::GestureStylusBuilder) which can be used to create [`GestureStylus`] objects.
+    pub fn builder() -> GestureStylusBuilder {
+        GestureStylusBuilder::new()
     }
 
     #[doc(alias = "gtk_gesture_stylus_get_axis")]
@@ -158,5 +166,82 @@ impl GestureStylus {
                 Box_::into_raw(f),
             )
         }
+    }
+}
+
+#[cfg(feature = "v3_24")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+impl Default for GestureStylus {
+    fn default() -> Self {
+        glib::object::Object::new::<Self>()
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// A [builder-pattern] type to construct [`GestureStylus`] objects.
+///
+/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
+#[must_use = "The builder must be built to be used"]
+pub struct GestureStylusBuilder {
+    builder: glib::object::ObjectBuilder<'static, GestureStylus>,
+}
+
+impl GestureStylusBuilder {
+    fn new() -> Self {
+        Self {
+            builder: glib::object::Object::builder(),
+        }
+    }
+
+    pub fn button(self, button: u32) -> Self {
+        Self {
+            builder: self.builder.property("button", button),
+        }
+    }
+
+    pub fn exclusive(self, exclusive: bool) -> Self {
+        Self {
+            builder: self.builder.property("exclusive", exclusive),
+        }
+    }
+
+    pub fn touch_only(self, touch_only: bool) -> Self {
+        Self {
+            builder: self.builder.property("touch-only", touch_only),
+        }
+    }
+
+    pub fn n_points(self, n_points: u32) -> Self {
+        Self {
+            builder: self.builder.property("n-points", n_points),
+        }
+    }
+
+    pub fn window(self, window: &gdk::Window) -> Self {
+        Self {
+            builder: self.builder.property("window", window.clone()),
+        }
+    }
+
+    pub fn propagation_phase(self, propagation_phase: PropagationPhase) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("propagation-phase", propagation_phase),
+        }
+    }
+
+    pub fn widget(self, widget: &impl IsA<Widget>) -> Self {
+        Self {
+            builder: self.builder.property("widget", widget.clone().upcast()),
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the [`GestureStylus`].
+    #[must_use = "Building the object from the builder is usually expensive and is not expected to have side effects"]
+    pub fn build(self) -> GestureStylus {
+        assert_initialized_main_thread!();
+        self.builder.build()
     }
 }

--- a/gtk/src/auto/mod.rs
+++ b/gtk/src/auto/mod.rs
@@ -1152,11 +1152,23 @@ pub(crate) mod builders {
     pub use super::entry::EntryBuilder;
     pub use super::entry_completion::EntryCompletionBuilder;
     pub use super::event_box::EventBoxBuilder;
+    #[cfg(feature = "v3_24")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+    pub use super::event_controller_key::EventControllerKeyBuilder;
+    #[cfg(feature = "v3_24")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+    pub use super::event_controller_motion::EventControllerMotionBuilder;
+    #[cfg(feature = "v3_24")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+    pub use super::event_controller_scroll::EventControllerScrollBuilder;
     pub use super::expander::ExpanderBuilder;
     pub use super::file_chooser_button::FileChooserButtonBuilder;
     pub use super::file_chooser_dialog::FileChooserDialogBuilder;
     pub use super::file_chooser_native::FileChooserNativeBuilder;
     pub use super::file_chooser_widget::FileChooserWidgetBuilder;
+    #[cfg(feature = "v3_24_30")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "v3_24_30")))]
+    pub use super::file_chooser_widget_accessible::FileChooserWidgetAccessibleBuilder;
     pub use super::fixed::FixedBuilder;
     pub use super::flow_box::FlowBoxBuilder;
     pub use super::flow_box_child::FlowBoxChildBuilder;
@@ -1169,6 +1181,9 @@ pub(crate) mod builders {
     pub use super::gesture_multi_press::GestureMultiPressBuilder;
     pub use super::gesture_pan::GesturePanBuilder;
     pub use super::gesture_rotate::GestureRotateBuilder;
+    #[cfg(feature = "v3_24")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+    pub use super::gesture_stylus::GestureStylusBuilder;
     pub use super::gesture_swipe::GestureSwipeBuilder;
     pub use super::gesture_zoom::GestureZoomBuilder;
     pub use super::gl_area::GLAreaBuilder;
@@ -1232,6 +1247,8 @@ pub(crate) mod builders {
     pub use super::separator::SeparatorBuilder;
     pub use super::separator_menu_item::SeparatorMenuItemBuilder;
     pub use super::separator_tool_item::SeparatorToolItemBuilder;
+    pub use super::settings::SettingsBuilder;
+    pub use super::shortcut_label::ShortcutLabelBuilder;
     pub use super::shortcuts_group::ShortcutsGroupBuilder;
     pub use super::shortcuts_section::ShortcutsSectionBuilder;
     pub use super::shortcuts_shortcut::ShortcutsShortcutBuilder;

--- a/gtk/src/auto/settings.rs
+++ b/gtk/src/auto/settings.rs
@@ -22,6 +22,14 @@ glib::wrapper! {
 impl Settings {
     pub const NONE: Option<&'static Settings> = None;
 
+    // rustdoc-stripper-ignore-next
+    /// Creates a new builder-pattern struct instance to construct [`Settings`] objects.
+    ///
+    /// This method returns an instance of [`SettingsBuilder`](crate::builders::SettingsBuilder) which can be used to create [`Settings`] objects.
+    pub fn builder() -> SettingsBuilder {
+        SettingsBuilder::new()
+    }
+
     #[doc(alias = "gtk_settings_get_default")]
     #[doc(alias = "get_default")]
     #[allow(clippy::should_implement_trait)]
@@ -35,6 +43,447 @@ impl Settings {
     pub fn for_screen(screen: &gdk::Screen) -> Option<Settings> {
         assert_initialized_main_thread!();
         unsafe { from_glib_none(ffi::gtk_settings_get_for_screen(screen.to_glib_none().0)) }
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// A [builder-pattern] type to construct [`Settings`] objects.
+///
+/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
+#[must_use = "The builder must be built to be used"]
+pub struct SettingsBuilder {
+    builder: glib::object::ObjectBuilder<'static, Settings>,
+}
+
+impl SettingsBuilder {
+    fn new() -> Self {
+        Self {
+            builder: glib::object::Object::builder(),
+        }
+    }
+
+    pub fn gtk_alternative_button_order(self, gtk_alternative_button_order: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-alternative-button-order", gtk_alternative_button_order),
+        }
+    }
+
+    pub fn gtk_alternative_sort_arrows(self, gtk_alternative_sort_arrows: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-alternative-sort-arrows", gtk_alternative_sort_arrows),
+        }
+    }
+
+    pub fn gtk_application_prefer_dark_theme(
+        self,
+        gtk_application_prefer_dark_theme: bool,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "gtk-application-prefer-dark-theme",
+                gtk_application_prefer_dark_theme,
+            ),
+        }
+    }
+
+    #[cfg(feature = "v3_24")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "v3_24")))]
+    pub fn gtk_cursor_aspect_ratio(self, gtk_cursor_aspect_ratio: f32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-cursor-aspect-ratio", gtk_cursor_aspect_ratio),
+        }
+    }
+
+    pub fn gtk_cursor_blink(self, gtk_cursor_blink: bool) -> Self {
+        Self {
+            builder: self.builder.property("gtk-cursor-blink", gtk_cursor_blink),
+        }
+    }
+
+    pub fn gtk_cursor_blink_time(self, gtk_cursor_blink_time: i32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-cursor-blink-time", gtk_cursor_blink_time),
+        }
+    }
+
+    pub fn gtk_cursor_blink_timeout(self, gtk_cursor_blink_timeout: i32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-cursor-blink-timeout", gtk_cursor_blink_timeout),
+        }
+    }
+
+    pub fn gtk_cursor_theme_name(self, gtk_cursor_theme_name: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-cursor-theme-name", gtk_cursor_theme_name.into()),
+        }
+    }
+
+    pub fn gtk_cursor_theme_size(self, gtk_cursor_theme_size: i32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-cursor-theme-size", gtk_cursor_theme_size),
+        }
+    }
+
+    pub fn gtk_decoration_layout(self, gtk_decoration_layout: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-decoration-layout", gtk_decoration_layout.into()),
+        }
+    }
+
+    pub fn gtk_dialogs_use_header(self, gtk_dialogs_use_header: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-dialogs-use-header", gtk_dialogs_use_header),
+        }
+    }
+
+    pub fn gtk_dnd_drag_threshold(self, gtk_dnd_drag_threshold: i32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-dnd-drag-threshold", gtk_dnd_drag_threshold),
+        }
+    }
+
+    pub fn gtk_double_click_distance(self, gtk_double_click_distance: i32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-double-click-distance", gtk_double_click_distance),
+        }
+    }
+
+    pub fn gtk_double_click_time(self, gtk_double_click_time: i32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-double-click-time", gtk_double_click_time),
+        }
+    }
+
+    pub fn gtk_enable_accels(self, gtk_enable_accels: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-enable-accels", gtk_enable_accels),
+        }
+    }
+
+    pub fn gtk_enable_animations(self, gtk_enable_animations: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-enable-animations", gtk_enable_animations),
+        }
+    }
+
+    pub fn gtk_enable_event_sounds(self, gtk_enable_event_sounds: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-enable-event-sounds", gtk_enable_event_sounds),
+        }
+    }
+
+    pub fn gtk_enable_input_feedback_sounds(self, gtk_enable_input_feedback_sounds: bool) -> Self {
+        Self {
+            builder: self.builder.property(
+                "gtk-enable-input-feedback-sounds",
+                gtk_enable_input_feedback_sounds,
+            ),
+        }
+    }
+
+    pub fn gtk_enable_primary_paste(self, gtk_enable_primary_paste: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-enable-primary-paste", gtk_enable_primary_paste),
+        }
+    }
+
+    pub fn gtk_entry_password_hint_timeout(self, gtk_entry_password_hint_timeout: u32) -> Self {
+        Self {
+            builder: self.builder.property(
+                "gtk-entry-password-hint-timeout",
+                gtk_entry_password_hint_timeout,
+            ),
+        }
+    }
+
+    pub fn gtk_entry_select_on_focus(self, gtk_entry_select_on_focus: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-entry-select-on-focus", gtk_entry_select_on_focus),
+        }
+    }
+
+    pub fn gtk_error_bell(self, gtk_error_bell: bool) -> Self {
+        Self {
+            builder: self.builder.property("gtk-error-bell", gtk_error_bell),
+        }
+    }
+
+    pub fn gtk_font_name(self, gtk_font_name: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("gtk-font-name", gtk_font_name.into()),
+        }
+    }
+
+    pub fn gtk_fontconfig_timestamp(self, gtk_fontconfig_timestamp: u32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-fontconfig-timestamp", gtk_fontconfig_timestamp),
+        }
+    }
+
+    pub fn gtk_icon_theme_name(self, gtk_icon_theme_name: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-icon-theme-name", gtk_icon_theme_name.into()),
+        }
+    }
+
+    pub fn gtk_im_module(self, gtk_im_module: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("gtk-im-module", gtk_im_module.into()),
+        }
+    }
+
+    pub fn gtk_key_theme_name(self, gtk_key_theme_name: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-key-theme-name", gtk_key_theme_name.into()),
+        }
+    }
+
+    pub fn gtk_keynav_use_caret(self, gtk_keynav_use_caret: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-keynav-use-caret", gtk_keynav_use_caret),
+        }
+    }
+
+    pub fn gtk_label_select_on_focus(self, gtk_label_select_on_focus: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-label-select-on-focus", gtk_label_select_on_focus),
+        }
+    }
+
+    pub fn gtk_long_press_time(self, gtk_long_press_time: u32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-long-press-time", gtk_long_press_time),
+        }
+    }
+
+    pub fn gtk_modules(self, gtk_modules: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("gtk-modules", gtk_modules.into()),
+        }
+    }
+
+    #[cfg(feature = "v3_24_9")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "v3_24_9")))]
+    pub fn gtk_overlay_scrolling(self, gtk_overlay_scrolling: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-overlay-scrolling", gtk_overlay_scrolling),
+        }
+    }
+
+    pub fn gtk_primary_button_warps_slider(self, gtk_primary_button_warps_slider: bool) -> Self {
+        Self {
+            builder: self.builder.property(
+                "gtk-primary-button-warps-slider",
+                gtk_primary_button_warps_slider,
+            ),
+        }
+    }
+
+    pub fn gtk_print_backends(self, gtk_print_backends: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-print-backends", gtk_print_backends.into()),
+        }
+    }
+
+    pub fn gtk_print_preview_command(
+        self,
+        gtk_print_preview_command: impl Into<glib::GString>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "gtk-print-preview-command",
+                gtk_print_preview_command.into(),
+            ),
+        }
+    }
+
+    pub fn gtk_recent_files_enabled(self, gtk_recent_files_enabled: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-recent-files-enabled", gtk_recent_files_enabled),
+        }
+    }
+
+    pub fn gtk_recent_files_max_age(self, gtk_recent_files_max_age: i32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-recent-files-max-age", gtk_recent_files_max_age),
+        }
+    }
+
+    pub fn gtk_shell_shows_app_menu(self, gtk_shell_shows_app_menu: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-shell-shows-app-menu", gtk_shell_shows_app_menu),
+        }
+    }
+
+    pub fn gtk_shell_shows_desktop(self, gtk_shell_shows_desktop: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-shell-shows-desktop", gtk_shell_shows_desktop),
+        }
+    }
+
+    pub fn gtk_shell_shows_menubar(self, gtk_shell_shows_menubar: bool) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-shell-shows-menubar", gtk_shell_shows_menubar),
+        }
+    }
+
+    pub fn gtk_sound_theme_name(self, gtk_sound_theme_name: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-sound-theme-name", gtk_sound_theme_name.into()),
+        }
+    }
+
+    pub fn gtk_split_cursor(self, gtk_split_cursor: bool) -> Self {
+        Self {
+            builder: self.builder.property("gtk-split-cursor", gtk_split_cursor),
+        }
+    }
+
+    pub fn gtk_theme_name(self, gtk_theme_name: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-theme-name", gtk_theme_name.into()),
+        }
+    }
+
+    pub fn gtk_titlebar_double_click(
+        self,
+        gtk_titlebar_double_click: impl Into<glib::GString>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "gtk-titlebar-double-click",
+                gtk_titlebar_double_click.into(),
+            ),
+        }
+    }
+
+    pub fn gtk_titlebar_middle_click(
+        self,
+        gtk_titlebar_middle_click: impl Into<glib::GString>,
+    ) -> Self {
+        Self {
+            builder: self.builder.property(
+                "gtk-titlebar-middle-click",
+                gtk_titlebar_middle_click.into(),
+            ),
+        }
+    }
+
+    pub fn gtk_titlebar_right_click(
+        self,
+        gtk_titlebar_right_click: impl Into<glib::GString>,
+    ) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-titlebar-right-click", gtk_titlebar_right_click.into()),
+        }
+    }
+
+    pub fn gtk_xft_antialias(self, gtk_xft_antialias: i32) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-xft-antialias", gtk_xft_antialias),
+        }
+    }
+
+    pub fn gtk_xft_dpi(self, gtk_xft_dpi: i32) -> Self {
+        Self {
+            builder: self.builder.property("gtk-xft-dpi", gtk_xft_dpi),
+        }
+    }
+
+    pub fn gtk_xft_hinting(self, gtk_xft_hinting: i32) -> Self {
+        Self {
+            builder: self.builder.property("gtk-xft-hinting", gtk_xft_hinting),
+        }
+    }
+
+    pub fn gtk_xft_hintstyle(self, gtk_xft_hintstyle: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("gtk-xft-hintstyle", gtk_xft_hintstyle.into()),
+        }
+    }
+
+    pub fn gtk_xft_rgba(self, gtk_xft_rgba: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("gtk-xft-rgba", gtk_xft_rgba.into()),
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the [`Settings`].
+    #[must_use = "Building the object from the builder is usually expensive and is not expected to have side effects"]
+    pub fn build(self) -> Settings {
+        assert_initialized_main_thread!();
+        self.builder.build()
     }
 }
 

--- a/gtk/src/auto/shortcut_label.rs
+++ b/gtk/src/auto/shortcut_label.rs
@@ -2,7 +2,10 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
-use crate::{Box, Buildable, Container, Orientable, Widget, ffi};
+use crate::{
+    Align, BaselinePosition, Box, Buildable, Container, Orientable, Orientation, ResizeMode,
+    Widget, ffi,
+};
 use glib::{
     prelude::*,
     signal::{SignalHandlerId, connect_raw},
@@ -27,6 +30,14 @@ impl ShortcutLabel {
             Widget::from_glib_none(ffi::gtk_shortcut_label_new(accelerator.to_glib_none().0))
                 .unsafe_cast()
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Creates a new builder-pattern struct instance to construct [`ShortcutLabel`] objects.
+    ///
+    /// This method returns an instance of [`ShortcutLabelBuilder`](crate::builders::ShortcutLabelBuilder) which can be used to create [`ShortcutLabel`] objects.
+    pub fn builder() -> ShortcutLabelBuilder {
+        ShortcutLabelBuilder::new()
     }
 
     #[doc(alias = "gtk_shortcut_label_get_accelerator")]
@@ -120,5 +131,286 @@ impl ShortcutLabel {
                 Box_::into_raw(f),
             )
         }
+    }
+}
+
+impl Default for ShortcutLabel {
+    fn default() -> Self {
+        glib::object::Object::new::<Self>()
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// A [builder-pattern] type to construct [`ShortcutLabel`] objects.
+///
+/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
+#[must_use = "The builder must be built to be used"]
+pub struct ShortcutLabelBuilder {
+    builder: glib::object::ObjectBuilder<'static, ShortcutLabel>,
+}
+
+impl ShortcutLabelBuilder {
+    fn new() -> Self {
+        Self {
+            builder: glib::object::Object::builder(),
+        }
+    }
+
+    pub fn accelerator(self, accelerator: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("accelerator", accelerator.into()),
+        }
+    }
+
+    pub fn disabled_text(self, disabled_text: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("disabled-text", disabled_text.into()),
+        }
+    }
+
+    pub fn baseline_position(self, baseline_position: BaselinePosition) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("baseline-position", baseline_position),
+        }
+    }
+
+    pub fn homogeneous(self, homogeneous: bool) -> Self {
+        Self {
+            builder: self.builder.property("homogeneous", homogeneous),
+        }
+    }
+
+    pub fn spacing(self, spacing: i32) -> Self {
+        Self {
+            builder: self.builder.property("spacing", spacing),
+        }
+    }
+
+    pub fn border_width(self, border_width: u32) -> Self {
+        Self {
+            builder: self.builder.property("border-width", border_width),
+        }
+    }
+
+    pub fn child(self, child: &impl IsA<Widget>) -> Self {
+        Self {
+            builder: self.builder.property("child", child.clone().upcast()),
+        }
+    }
+
+    pub fn resize_mode(self, resize_mode: ResizeMode) -> Self {
+        Self {
+            builder: self.builder.property("resize-mode", resize_mode),
+        }
+    }
+
+    pub fn app_paintable(self, app_paintable: bool) -> Self {
+        Self {
+            builder: self.builder.property("app-paintable", app_paintable),
+        }
+    }
+
+    pub fn can_default(self, can_default: bool) -> Self {
+        Self {
+            builder: self.builder.property("can-default", can_default),
+        }
+    }
+
+    pub fn can_focus(self, can_focus: bool) -> Self {
+        Self {
+            builder: self.builder.property("can-focus", can_focus),
+        }
+    }
+
+    pub fn events(self, events: gdk::EventMask) -> Self {
+        Self {
+            builder: self.builder.property("events", events),
+        }
+    }
+
+    pub fn expand(self, expand: bool) -> Self {
+        Self {
+            builder: self.builder.property("expand", expand),
+        }
+    }
+
+    pub fn focus_on_click(self, focus_on_click: bool) -> Self {
+        Self {
+            builder: self.builder.property("focus-on-click", focus_on_click),
+        }
+    }
+
+    pub fn halign(self, halign: Align) -> Self {
+        Self {
+            builder: self.builder.property("halign", halign),
+        }
+    }
+
+    pub fn has_default(self, has_default: bool) -> Self {
+        Self {
+            builder: self.builder.property("has-default", has_default),
+        }
+    }
+
+    pub fn has_focus(self, has_focus: bool) -> Self {
+        Self {
+            builder: self.builder.property("has-focus", has_focus),
+        }
+    }
+
+    pub fn has_tooltip(self, has_tooltip: bool) -> Self {
+        Self {
+            builder: self.builder.property("has-tooltip", has_tooltip),
+        }
+    }
+
+    pub fn height_request(self, height_request: i32) -> Self {
+        Self {
+            builder: self.builder.property("height-request", height_request),
+        }
+    }
+
+    pub fn hexpand(self, hexpand: bool) -> Self {
+        Self {
+            builder: self.builder.property("hexpand", hexpand),
+        }
+    }
+
+    pub fn hexpand_set(self, hexpand_set: bool) -> Self {
+        Self {
+            builder: self.builder.property("hexpand-set", hexpand_set),
+        }
+    }
+
+    pub fn is_focus(self, is_focus: bool) -> Self {
+        Self {
+            builder: self.builder.property("is-focus", is_focus),
+        }
+    }
+
+    pub fn margin(self, margin: i32) -> Self {
+        Self {
+            builder: self.builder.property("margin", margin),
+        }
+    }
+
+    pub fn margin_bottom(self, margin_bottom: i32) -> Self {
+        Self {
+            builder: self.builder.property("margin-bottom", margin_bottom),
+        }
+    }
+
+    pub fn margin_end(self, margin_end: i32) -> Self {
+        Self {
+            builder: self.builder.property("margin-end", margin_end),
+        }
+    }
+
+    pub fn margin_start(self, margin_start: i32) -> Self {
+        Self {
+            builder: self.builder.property("margin-start", margin_start),
+        }
+    }
+
+    pub fn margin_top(self, margin_top: i32) -> Self {
+        Self {
+            builder: self.builder.property("margin-top", margin_top),
+        }
+    }
+
+    pub fn name(self, name: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("name", name.into()),
+        }
+    }
+
+    pub fn no_show_all(self, no_show_all: bool) -> Self {
+        Self {
+            builder: self.builder.property("no-show-all", no_show_all),
+        }
+    }
+
+    pub fn opacity(self, opacity: f64) -> Self {
+        Self {
+            builder: self.builder.property("opacity", opacity),
+        }
+    }
+
+    pub fn parent(self, parent: &impl IsA<Container>) -> Self {
+        Self {
+            builder: self.builder.property("parent", parent.clone().upcast()),
+        }
+    }
+
+    pub fn receives_default(self, receives_default: bool) -> Self {
+        Self {
+            builder: self.builder.property("receives-default", receives_default),
+        }
+    }
+
+    pub fn sensitive(self, sensitive: bool) -> Self {
+        Self {
+            builder: self.builder.property("sensitive", sensitive),
+        }
+    }
+
+    pub fn tooltip_markup(self, tooltip_markup: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self
+                .builder
+                .property("tooltip-markup", tooltip_markup.into()),
+        }
+    }
+
+    pub fn tooltip_text(self, tooltip_text: impl Into<glib::GString>) -> Self {
+        Self {
+            builder: self.builder.property("tooltip-text", tooltip_text.into()),
+        }
+    }
+
+    pub fn valign(self, valign: Align) -> Self {
+        Self {
+            builder: self.builder.property("valign", valign),
+        }
+    }
+
+    pub fn vexpand(self, vexpand: bool) -> Self {
+        Self {
+            builder: self.builder.property("vexpand", vexpand),
+        }
+    }
+
+    pub fn vexpand_set(self, vexpand_set: bool) -> Self {
+        Self {
+            builder: self.builder.property("vexpand-set", vexpand_set),
+        }
+    }
+
+    pub fn visible(self, visible: bool) -> Self {
+        Self {
+            builder: self.builder.property("visible", visible),
+        }
+    }
+
+    pub fn width_request(self, width_request: i32) -> Self {
+        Self {
+            builder: self.builder.property("width-request", width_request),
+        }
+    }
+
+    pub fn orientation(self, orientation: Orientation) -> Self {
+        Self {
+            builder: self.builder.property("orientation", orientation),
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the [`ShortcutLabel`].
+    #[must_use = "Building the object from the builder is usually expensive and is not expected to have side effects"]
+    pub fn build(self) -> ShortcutLabel {
+        assert_initialized_main_thread!();
+        self.builder.build()
     }
 }


### PR DESCRIPTION
This sets the global `generate_builder = true` in gtk's Gir.toml, and then opts out specific classes that shouldn't have one.  We get seven more builders out of this.