### PR TITLE
Don't generate getter for the `GtkWindow:type` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,9 @@
   Code using `gtk::prelude::*` is unaffected, but code that imports
   `WidgetExt` by name, or that calls either method through it, must be
   updated.
+- `gtk::WindowExt::type_()` has been removed, because it awkwardly
+  conflicts with `glib::ObjectExt::type_()`.  Use
+  `gtk::WindowExt::window_type()` instead.
 - The hand-written `MessageDialogExt` has been renamed to
   `MessageDialogExtManual`, and its methods now match the C functions
   they call: `set_secondary_markup()` is now

--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -2838,6 +2838,10 @@ name = "Gtk.Window"
 status = "generate"
 trait_name = "GtkWindowExt"
 manual_traits = ["GtkWindowExtManual"]
+    [[object.property]]
+    name = "type"
+    # the getter collides with glib::ObjectExt::type_(); use window_type()
+    generate = []
     [[object.function]]
     name = "activate_key"
         [[object.function.parameter]]

--- a/gtk/src/auto/window.rs
+++ b/gtk/src/auto/window.rs
@@ -1490,11 +1490,6 @@ pub trait GtkWindowExt: IsA<Window> + 'static {
         ObjectExt::set_property(self.as_ref(), "default-width", default_width)
     }
 
-    #[doc(alias = "type")]
-    fn type_(&self) -> WindowType {
-        ObjectExt::property(self.as_ref(), "type")
-    }
-
     #[doc(alias = "window-position")]
     fn window_position(&self) -> WindowPosition {
         ObjectExt::property(self.as_ref(), "window-position")


### PR DESCRIPTION
This generates `gtk::WindowExt::type_()`, which awkwardly conflicts with `glib::ObjectExt::type_()`.  `gtk::WindowExt::window_type()` already exists and returns the same thing.